### PR TITLE
feat: add a way to create LocalVideoTracks from VideoCapturers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,23 +7,35 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `Conference.name` property
+- `WebRtcMediaConnectionFactory.createLocalVideoTrack` that accepts `VideoCapturer`
+
 ## [0.11.0] - 2022-12-15
 
 ### Added
+
 - `WebRtcMediaConnectionFactory.Builder` to improve experience for both Java and Kotlin users
-- `MediaConnection.setPresentationRemoteVideoTrackEnabled` that allows to configure whether the `MediaConnection` should be receiving remote presentation
-- `MediaConnection.setMainRemoteAudioTrackEnabled`/`MediaConnection.setMainRemoteVideoTrackEnabled` to control whether the main remote audio/video should be enabled
+- `MediaConnection.setPresentationRemoteVideoTrackEnabled` that allows to configure whether
+  the `MediaConnection` should be receiving remote presentation
+- `MediaConnection.setMainRemoteAudioTrackEnabled`/`MediaConnection.setMainRemoteVideoTrackEnabled`
+  to control whether the main remote audio/video should be enabled
 - `MediaConnection.setMaxBitrate` that controls maximum bitrate for each video stream
 - Several new properties on `RequestTokenResponse` and `Registration`
 - Ability to retrieve registered devices via `Registration.getRegisteredDevices`
 
 ### Changed
+
 - Kotlin to 1.7.20
 - `EglBase` is now nullable
 - Deprecate `WebRtcMediaConnectionFactory` constructor, please migrate to `Builder`
-- **BREAKING**: `MediaConnection.setMainAudioTrack`/`MediaConnection.setMainVideoTrack` no longer enable remote audio/video by default. Please use `MediaConnection.setMainRemoteAudioTrackEnabled`/`MediaConnection.setMainRemoteVideoTrackEnabled` to enable them
+- **BREAKING**: `MediaConnection.setMainAudioTrack`/`MediaConnection.setMainVideoTrack` no longer
+  enable remote audio/video by default. Please use `MediaConnection.setMainRemoteAudioTrackEnabled`
+  /`MediaConnection.setMainRemoteVideoTrackEnabled` to enable them
 
 ### Fixed
+
 - Microphone mute state not being restored after `LocalAudioTrack.dispose` call
 
 ## [0.10.0] - 2022-09-23

--- a/sdk-media-webrtc/api/sdk-media-webrtc.api
+++ b/sdk-media-webrtc/api/sdk-media-webrtc.api
@@ -16,6 +16,7 @@ public final class com/pexip/sdk/media/webrtc/WebRtcMediaConnectionFactory : com
 	public fun createCameraVideoTrack (Ljava/lang/String;)Lcom/pexip/sdk/media/CameraVideoTrack;
 	public fun createCameraVideoTrack (Ljava/lang/String;Lcom/pexip/sdk/media/CameraVideoTrack$Callback;)Lcom/pexip/sdk/media/CameraVideoTrack;
 	public fun createLocalAudioTrack ()Lcom/pexip/sdk/media/LocalAudioTrack;
+	public final fun createLocalVideoTrack (Lorg/webrtc/VideoCapturer;)Lcom/pexip/sdk/media/LocalVideoTrack;
 	public fun createMediaConnection (Lcom/pexip/sdk/media/MediaConnectionConfig;)Lcom/pexip/sdk/media/MediaConnection;
 	public fun createMediaProjectionVideoTrack (Landroid/content/Intent;Landroid/media/projection/MediaProjection$Callback;)Lcom/pexip/sdk/media/LocalVideoTrack;
 	public fun dispose ()V

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/WebRtcMediaConnectionFactory.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/WebRtcMediaConnectionFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pexip AS
+ * Copyright 2022-2023 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,6 +46,7 @@ import org.webrtc.MediaConstraints
 import org.webrtc.PeerConnection
 import org.webrtc.PeerConnectionFactory
 import org.webrtc.ScreenCapturerAndroid
+import org.webrtc.VideoCapturer
 import org.webrtc.VideoDecoderFactory
 import org.webrtc.VideoEncoderFactory
 import org.webrtc.audio.AudioDeviceModule
@@ -189,6 +190,20 @@ public class WebRtcMediaConnectionFactory private constructor(
     ): LocalVideoTrack {
         checkNotDisposed()
         val videoCapturer = ScreenCapturerAndroid(intent, callback)
+        return createLocalVideoTrack(videoCapturer)
+    }
+
+    /**
+     * Creates a [LocalVideoTrack] backed by the provided [VideoCapturer].
+     *
+     * [VideoCapturer] will be managed by [LocalVideoTrack].
+     *
+     * @param videoCapturer a [VideoCapturer]
+     * @return a [VideoCapturer]-backed [LocalVideoTrack]
+     * @throws IllegalStateException if [MediaConnectionFactory] has been disposed
+     */
+    public fun createLocalVideoTrack(videoCapturer: VideoCapturer): LocalVideoTrack {
+        checkNotDisposed()
         val videoSource = factory.createVideoSource(videoCapturer.isScreencast)
         return WebRtcLocalVideoTrack(
             applicationContext = applicationContext,


### PR DESCRIPTION
This change should help bridge the already-available implementations of
`VideoCapturer` and `LocalVideoTrack` provided by the SDK.
