### PR TITLE
fix(catalog): ensure that version catalog contains all relevant modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - WebRTC to M110
 - **BREAKING**: `MessageRequest` no longer has a default `type` set
 
+### Fixed
+
+- Gradle Version Catalog missing a few entries
+
 ## [0.11.0] - 2022-12-15
 
 ### Added

--- a/sdk-catalog/build.gradle.kts
+++ b/sdk-catalog/build.gradle.kts
@@ -5,22 +5,16 @@ plugins {
 
 catalog {
     versionCatalog {
-        val aliases = listOf(
-            "api",
-            "api-coroutines",
-            "api-infinity",
-            "conference",
-            "conference-coroutines",
-            "conference-infinity",
-            "registration",
-            "registration-coroutines",
-            "registration-infinity",
-            "media",
-            "media-coroutines",
-            "media-webrtc",
-            "media-webrtc-compose",
-        )
-        aliases.forEach { alias -> library(alias, "$group:sdk-$alias:$version") }
+        val prefix = "sdk-"
+        rootProject.childProjects.values.asSequence()
+            .filter { it != project && it.name.startsWith(prefix) }
+            .forEach {
+                val artifact = it.name
+                val alias = artifact.removePrefix(prefix)
+                val group = group.toString()
+                val version = version.toString()
+                library(alias, group, artifact).version(version)
+            }
     }
 }
 


### PR DESCRIPTION
Specifically, `pexipSdk.media.android` was missing.
