### PR TITLE
ci: switch to snyk/actions/setup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,10 +45,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: snyk/actions/gradle-jdk11@master
+      - uses: snyk/actions/setup@master
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'gradle'
+
+      - run: snyk monitor --all-sub-projects --remote-repo-url=$GITHUB_REPOSITORY
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_CFG_ORG: ${{ secrets.SNYK_CFG_ORG }}
-        with:
-          command: monitor
-          args: --all-sub-projects --remote-repo-url=$GITHUB_REPOSITORY

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -30,9 +30,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - uses: snyk/actions/gradle-jdk11@master
+      - uses: snyk/actions/setup@master
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
+          cache: 'gradle'
+
+      - run: snyk test --all-sub-projects --severity-threshold=high
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_CFG_ORG: ${{ secrets.SNYK_CFG_ORG }}
-        with:
-          args: --all-sub-projects --severity-threshold=high


### PR DESCRIPTION
`snyk/actions/gradle-jdk11` started to fail after upgrading to Gradle 8. Migrating to `snyk/actions/setup` seems to fix that.