### PR TITLE
ci: manually specify google maven repo

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,15 @@ updates:
       prefix: "feat"
       include: "scope"
 
-  - package-ecosystem: gradle
+  - package-ecosystem: "gradle"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "feat"
       include: "scope"
+
+registries:
+  maven-google:
+    type: maven-repository
+    url: "https://dl.google.com/dl/android/maven2/"


### PR DESCRIPTION
It appears that Dependabot doesn't take repositories specified in
`settings.gradle.kts` into account and we're not notified of
Android dependency updates.

https://github.com/dependabot/dependabot-core/issues/3286
