### PR TITLE
fix(sample): crash when calling FocusRequester.freeFocus()

### DIFF
--- a/sample/src/main/kotlin/com/pexip/sdk/sample/alias/AliasScreen.kt
+++ b/sample/src/main/kotlin/com/pexip/sdk/sample/alias/AliasScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -64,9 +64,8 @@ fun AliasScreen(rendering: AliasRendering, modifier: Modifier = Modifier) {
                     )
                 }
                 val focusRequester = remember { FocusRequester() }
-                DisposableEffect(focusRequester) {
+                LaunchedEffect(focusRequester) {
                     focusRequester.requestFocus()
-                    onDispose { focusRequester.freeFocus() }
                 }
                 TextField(
                     value = rendering.alias,

--- a/sample/src/main/kotlin/com/pexip/sdk/sample/displayname/DisplayNameScreen.kt
+++ b/sample/src/main/kotlin/com/pexip/sdk/sample/displayname/DisplayNameScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
@@ -65,9 +65,8 @@ fun DisplayNameScreen(rendering: DisplayNameRendering, modifier: Modifier = Modi
                     KeyboardActions(onGo = { currentOnNextClick() })
                 }
                 val focusRequester = remember { FocusRequester() }
-                DisposableEffect(focusRequester) {
+                LaunchedEffect(focusRequester) {
                     focusRequester.requestFocus()
-                    onDispose { focusRequester.freeFocus() }
                 }
                 TextField(
                     value = rendering.displayName,

--- a/sample/src/main/kotlin/com/pexip/sdk/sample/pinchallenge/PinChallengeScreen.kt
+++ b/sample/src/main/kotlin/com/pexip/sdk/sample/pinchallenge/PinChallengeScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -59,9 +59,8 @@ fun PinChallengeScreen(rendering: PinChallengeRendering, modifier: Modifier = Mo
                     )
                 }
                 val focusRequester = remember { FocusRequester() }
-                DisposableEffect(focusRequester) {
+                LaunchedEffect(focusRequester) {
                     focusRequester.requestFocus()
-                    onDispose { focusRequester.freeFocus() }
                 }
                 TextField(
                     value = rendering.pin,


### PR DESCRIPTION
It's only necessary to invoke this method to match previous
`FocusRequester.captureFocus()`. Since we don't do that, it crashes the
app.
