### PR TITLE
feat: build with jdk11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: 'zulu'
+          java-version: '17'
           cache: 'gradle'
 
       - run: ./gradlew build
@@ -51,8 +51,8 @@ jobs:
       - uses: snyk/actions/setup@master
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: 'zulu'
+          java-version: '17'
           cache: 'gradle'
 
       - run: snyk test --all-sub-projects --sarif-file-output=snyk.sarif
@@ -73,8 +73,8 @@ jobs:
       - uses: snyk/actions/setup@master
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: 'zulu'
+          java-version: '17'
           cache: 'gradle'
 
       - run: snyk monitor --all-sub-projects --remote-repo-url=$GITHUB_REPOSITORY

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -20,8 +20,8 @@ jobs:
 
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: 'zulu'
+          java-version: '17'
           cache: 'gradle'
 
       - run: ./gradlew build
@@ -37,8 +37,8 @@ jobs:
       - uses: snyk/actions/setup@master
       - uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
-          java-version: '11'
+          distribution: 'zulu'
+          java-version: '17'
           cache: 'gradle'
 
       - run: snyk test --all-sub-projects --severity-threshold=high

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,11 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
     <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value />
-      </option>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.8.20-RC" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ repositories {
 
 ## Requirements
 
-* JDK 8
+* JDK 11
 * Android SDK 21+
 
 ## WebRTC versions

--- a/plugins/android/build.gradle.kts
+++ b/plugins/android/build.gradle.kts
@@ -3,9 +3,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain {
-        languageVersion.set(JavaLanguageVersion.of(11))
-    }
+    jvmToolchain(17)
 }
 
 dependencies {

--- a/plugins/android/src/main/kotlin/com.pexip.sdk.android.application.gradle.kts
+++ b/plugins/android/src/main/kotlin/com.pexip.sdk.android.application.gradle.kts
@@ -36,6 +36,12 @@ android {
     }
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 tasks.withType<Test>().configureEach {
     testLogging.exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 }

--- a/plugins/android/src/main/kotlin/com.pexip.sdk.android.library.gradle.kts
+++ b/plugins/android/src/main/kotlin/com.pexip.sdk.android.library.gradle.kts
@@ -31,6 +31,12 @@ android {
     }
 }
 
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(11))
+    }
+}
+
 tasks.withType<Test>().configureEach {
     testLogging.exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 }

--- a/plugins/android/src/main/kotlin/com.pexip.sdk.kotlin.android.application.gradle.kts
+++ b/plugins/android/src/main/kotlin/com.pexip.sdk.kotlin.android.application.gradle.kts
@@ -10,12 +10,6 @@ dependencies {
     androidTestImplementation(kotlin("test-junit"))
 }
 
-tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
-    compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
-    }
-}
-
 tasks.withType<Test>().configureEach {
     systemProperty("kotlinx.coroutines.stacktrace.recovery", false)
 }

--- a/plugins/android/src/main/kotlin/com.pexip.sdk.kotlin.android.library.gradle.kts
+++ b/plugins/android/src/main/kotlin/com.pexip.sdk.kotlin.android.library.gradle.kts
@@ -12,7 +12,6 @@ dependencies {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().configureEach {
     compilerOptions {
-        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8)
         freeCompilerArgs.add("-Xexplicit-api=strict")
     }
 }

--- a/plugins/android/src/main/kotlin/internal/Android.kt
+++ b/plugins/android/src/main/kotlin/internal/Android.kt
@@ -26,8 +26,8 @@ internal object Android {
     const val testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     const val composeCompilerExtensionVersion = "1.4.4"
 
-    val sourceCompatibility = JavaVersion.VERSION_1_8
-    val targetCompatibility = JavaVersion.VERSION_1_8
+    val sourceCompatibility = JavaVersion.VERSION_11
+    val targetCompatibility = JavaVersion.VERSION_11
 
     val resourcesExcludes = setOf("META-INF/AL2.0", "META-INF/LGPL2.1")
 }

--- a/plugins/kotlin/build.gradle.kts
+++ b/plugins/kotlin/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 kotlin {
-    jvmToolchain(11)
+    jvmToolchain(17)
 }
 
 dependencies {

--- a/plugins/kotlin/src/main/kotlin/com.pexip.sdk.kotlin.jvm.gradle.kts
+++ b/plugins/kotlin/src/main/kotlin/com.pexip.sdk.kotlin.jvm.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 kotlin {
     explicitApi()
-    jvmToolchain(8)
+    jvmToolchain(11)
 }
 
 dependencies {


### PR DESCRIPTION
Some of our dependencies (primarily WebRTC) have switched to JDK11, so we also start building with them.

Note that the plugins (and CI) are JDK17 in preparation for AGP 8.0.