### PR TITLE
refactor(media): defer ack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,12 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Various deprecated methods `DeprecationLevel` to `DeprecationLevel.ERROR`
+- `ack` is now called later in the call setup phase
 
 ### Removed
 
 - Various deprecated methods with `DeprecationLevel.ERROR`
+- Read timeout on `ack`
 
 ## [0.12.0] - 2023-05-22
 

--- a/sdk-conference-infinity/api/sdk-conference-infinity.api
+++ b/sdk-conference-infinity/api/sdk-conference-infinity.api
@@ -8,6 +8,7 @@ public final class com/pexip/sdk/conference/infinity/InfinityConference : com/pe
 	public fun getName ()Ljava/lang/String;
 	public fun leave ()V
 	public fun message (Ljava/lang/String;)V
+	public fun onAck ()V
 	public fun onAudioMuted ()V
 	public fun onAudioUnmuted ()V
 	public fun onCandidate (Ljava/lang/String;Ljava/lang/String;)V

--- a/sdk-conference-infinity/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RealMediaConnectionSignaling.kt
+++ b/sdk-conference-infinity/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RealMediaConnectionSignaling.kt
@@ -52,7 +52,6 @@ internal class RealMediaConnectionSignaling(
                 )
                 val response = participantStep.calls(request, token).execute()
                 callStep = participantStep.call(response.callId)
-                callStep!!.ack(token).execute()
                 response.sdp
             }
             else -> {
@@ -64,6 +63,12 @@ internal class RealMediaConnectionSignaling(
                 response.sdp
             }
         }
+    }
+
+    override fun onAck() {
+        val callStep = checkNotNull(callStep) { "callStep is not set." }
+        val token = store.get()
+        callStep.ack(token).execute()
     }
 
     override fun onCandidate(candidate: String, mid: String) {

--- a/sdk-conference-infinity/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RealMediaConnectionSignalingTest.kt
+++ b/sdk-conference-infinity/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RealMediaConnectionSignalingTest.kt
@@ -152,6 +152,27 @@ internal class RealMediaConnectionSignalingTest {
     }
 
     @Test
+    fun `onAck() returns`() {
+        var called = false
+        val signaling = RealMediaConnectionSignaling(
+            store = store,
+            participantStep = object : TestParticipantStep() {},
+            iceServers = iceServers,
+        )
+        signaling.callStep = object : TestCallStep() {
+
+            override fun ack(token: String): Call<Unit> = object : TestCall<Unit> {
+
+                override fun execute() {
+                    called = true
+                }
+            }
+        }
+        signaling.onAck()
+        assertTrue(called)
+    }
+
+    @Test
     fun `onCandidate() returns`() {
         var called = false
         val candidate =

--- a/sdk-media/api/sdk-media.api
+++ b/sdk-media/api/sdk-media.api
@@ -195,6 +195,7 @@ public abstract interface class com/pexip/sdk/media/MediaConnectionFactory : com
 
 public abstract interface class com/pexip/sdk/media/MediaConnectionSignaling {
 	public abstract fun getIceServers ()Ljava/util/List;
+	public abstract fun onAck ()V
 	public abstract fun onAudioMuted ()V
 	public abstract fun onAudioUnmuted ()V
 	public abstract fun onCandidate (Ljava/lang/String;Ljava/lang/String;)V

--- a/sdk-media/src/main/kotlin/com/pexip/sdk/media/MediaConnectionSignaling.kt
+++ b/sdk-media/src/main/kotlin/com/pexip/sdk/media/MediaConnectionSignaling.kt
@@ -42,6 +42,11 @@ public interface MediaConnectionSignaling {
     ): String
 
     /**
+     * Invoked when offer is set and the connection is ready to accept media.
+     */
+    public fun onAck()
+
+    /**
      * Invoked when a new ICE candidate is available.
      *
      * @param candidate an ICE candidate


### PR DESCRIPTION
This should help with the _broken camera_ icon in gateway calls by
letting the `MediaConnection` have answer set earlier.
