### PR TITLE
refactor(media, conference)!: make MediaConnectionSignaling a property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Merged all `-coroutines` modules with their respective bases
 - `createOffer` to `setLocalDescription` that supports rollback
 - Usages of `java.net.URL` to `okhttp3.HttpUrl` internally
+- **BREAKING**: `Conference` no longer implements `MediaConnectionSignaling`. It instead provides an
+  instance of `MediaConnectionSignaling` as a property `Conference.signaling`. To migrated, update
+  the any calls of `MediaConnectionConfig.Builder(conference)` to
+  `MediaConnectionConfig.Builder(conference.signaling)`
 
 ### Fixed
 

--- a/sample/src/main/kotlin/com/pexip/sdk/sample/conference/ConferenceWorkflow.kt
+++ b/sample/src/main/kotlin/com/pexip/sdk/sample/conference/ConferenceWorkflow.kt
@@ -83,7 +83,7 @@ class ConferenceWorkflow @Inject constructor(
             response = props.response,
         )
         val iceServer = IceServer.Builder(GoogleStunUrls).build()
-        val config = MediaConnectionConfig.Builder(conference)
+        val config = MediaConnectionConfig.Builder(conference.signaling)
             .addIceServer(iceServer)
             .presentationInMain(props.presentationInMain)
             .build()

--- a/sdk-conference-infinity/api/sdk-conference-infinity.api
+++ b/sdk-conference-infinity/api/sdk-conference-infinity.api
@@ -1,23 +1,13 @@
-public final class com/pexip/sdk/conference/infinity/InfinityConference : com/pexip/sdk/conference/Conference, com/pexip/sdk/media/MediaConnectionSignaling {
+public final class com/pexip/sdk/conference/infinity/InfinityConference : com/pexip/sdk/conference/Conference {
 	public static final field Companion Lcom/pexip/sdk/conference/infinity/InfinityConference$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lcom/pexip/sdk/conference/Messenger;Lcom/pexip/sdk/conference/infinity/internal/ConferenceEventSource;Lcom/pexip/sdk/api/infinity/TokenRefresher;Lcom/pexip/sdk/media/MediaConnectionSignaling;Ljava/util/concurrent/ScheduledExecutorService;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun create (Lcom/pexip/sdk/api/infinity/InfinityService$ConferenceStep;Lcom/pexip/sdk/api/infinity/RequestTokenResponse;)Lcom/pexip/sdk/conference/infinity/InfinityConference;
 	public static final fun create (Lcom/pexip/sdk/api/infinity/InfinityService;Ljava/net/URL;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/RequestTokenResponse;)Lcom/pexip/sdk/conference/infinity/InfinityConference;
-	public fun getIceServers ()Ljava/util/List;
 	public fun getMessenger ()Lcom/pexip/sdk/conference/Messenger;
 	public fun getName ()Ljava/lang/String;
+	public fun getSignaling ()Lcom/pexip/sdk/media/MediaConnectionSignaling;
 	public fun leave ()V
 	public fun message (Ljava/lang/String;)V
-	public fun onAck ()V
-	public fun onAudioMuted ()V
-	public fun onAudioUnmuted ()V
-	public fun onCandidate (Ljava/lang/String;Ljava/lang/String;)V
-	public fun onDtmf (Ljava/lang/String;)V
-	public fun onOffer (Ljava/lang/String;Ljava/lang/String;ZZ)Ljava/lang/String;
-	public fun onReleaseFloor ()V
-	public fun onTakeFloor ()V
-	public fun onVideoMuted ()V
-	public fun onVideoUnmuted ()V
 	public fun registerConferenceEventListener (Lcom/pexip/sdk/conference/ConferenceEventListener;)V
 	public fun unregisterConferenceEventListener (Lcom/pexip/sdk/conference/ConferenceEventListener;)V
 }

--- a/sdk-conference-infinity/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
+++ b/sdk-conference-infinity/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
@@ -44,9 +44,9 @@ public class InfinityConference private constructor(
     override val messenger: Messenger,
     private val source: ConferenceEventSource,
     private val refresher: TokenRefresher,
-    private val signaling: MediaConnectionSignaling,
+    override val signaling: MediaConnectionSignaling,
     private val executor: ScheduledExecutorService,
-) : Conference, MediaConnectionSignaling by signaling {
+) : Conference {
 
     override fun registerConferenceEventListener(listener: ConferenceEventListener) {
         source.registerConferenceEventListener(listener)

--- a/sdk-conference/api/sdk-conference.api
+++ b/sdk-conference/api/sdk-conference.api
@@ -1,6 +1,7 @@
-public abstract interface class com/pexip/sdk/conference/Conference : com/pexip/sdk/media/MediaConnectionSignaling {
+public abstract interface class com/pexip/sdk/conference/Conference {
 	public abstract fun getMessenger ()Lcom/pexip/sdk/conference/Messenger;
 	public abstract fun getName ()Ljava/lang/String;
+	public abstract fun getSignaling ()Lcom/pexip/sdk/media/MediaConnectionSignaling;
 	public abstract fun leave ()V
 	public abstract fun message (Ljava/lang/String;)V
 	public abstract fun registerConferenceEventListener (Lcom/pexip/sdk/conference/ConferenceEventListener;)V

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Conference.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Conference.kt
@@ -15,6 +15,7 @@
  */
 package com.pexip.sdk.conference
 
+import com.pexip.sdk.media.MediaConnection
 import com.pexip.sdk.media.MediaConnectionSignaling
 
 /**
@@ -22,12 +23,15 @@ import com.pexip.sdk.media.MediaConnectionSignaling
  *
  * @property name a display name of this [Conference]
  * @property messenger an instance of [Messenger] attached to this [Conference]
+ * @property signaling an instance of [MediaConnectionSignaling] to be used with [MediaConnection]
  */
-public interface Conference : MediaConnectionSignaling {
+public interface Conference {
 
     public val name: String
 
     public val messenger: Messenger
+
+    public val signaling: MediaConnectionSignaling
 
     /**
      * Registers a [ConferenceEventListener].


### PR DESCRIPTION
The move is motivated by the following:
1. Modifying `MediaConnectionSignaling` also affects `Conference` API, which often leads to tests not compiling (i.e. if a new method is added)
2. It may prove useful to be able to create new instances of `MediaConnectionSignaling` upon invocation (for scoping purposes)

This is a breaking change and consumers will be unable to compile after the update. The fix is to change `MediaConnectionConfig.Builder(conference)` to `MediaConnectionConfig.Builder(conference.signaling)`.
