### PR TITLE
fix(media): pin MediaConnectionFactory-produced objects to a single thread

### DIFF
--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
@@ -18,6 +18,7 @@ package com.pexip.sdk.media.webrtc.internal
 import android.content.Context
 import com.pexip.sdk.media.CameraVideoTrack
 import com.pexip.sdk.media.CameraVideoTrackFactory
+import kotlinx.coroutines.CompletableJob
 import org.webrtc.CameraVideoCapturer
 import org.webrtc.EglBase
 import org.webrtc.VideoSource
@@ -34,6 +35,7 @@ internal class WebRtcCameraVideoTrack(
     videoTrack: VideoTrack,
     workerExecutor: Executor,
     signalingExecutor: Executor,
+    job: CompletableJob,
 ) : CameraVideoTrack, WebRtcLocalVideoTrack(
     applicationContext = applicationContext,
     eglBase = eglBase,
@@ -42,6 +44,7 @@ internal class WebRtcCameraVideoTrack(
     videoTrack = videoTrack,
     workerExecutor = workerExecutor,
     signalingExecutor = signalingExecutor,
+    job = job,
 ) {
 
     override fun switchCamera(callback: CameraVideoTrack.SwitchCameraCallback) {

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pexip AS
+ * Copyright 2022-2023 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.pexip.sdk.media.webrtc.internal
 import android.content.Context
 import com.pexip.sdk.media.LocalAudioTrack
 import com.pexip.sdk.media.LocalMediaTrack
+import kotlinx.coroutines.CompletableJob
 import org.webrtc.AudioSource
 import org.webrtc.AudioTrack
 import java.util.concurrent.CopyOnWriteArraySet
@@ -30,6 +31,7 @@ internal class WebRtcLocalAudioTrack(
     internal val audioTrack: AudioTrack,
     private val workerExecutor: Executor,
     private val signalingExecutor: Executor,
+    private val job: CompletableJob,
 ) : LocalAudioTrack {
 
     private val disposed = AtomicBoolean()
@@ -71,6 +73,7 @@ internal class WebRtcLocalAudioTrack(
                 microphoneMuteObserver.dispose()
                 audioTrack.dispose()
                 audioSource.dispose()
+                job.complete()
             }
         }
     }

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
@@ -20,6 +20,7 @@ import com.pexip.sdk.media.LocalMediaTrack
 import com.pexip.sdk.media.LocalVideoTrack
 import com.pexip.sdk.media.QualityProfile
 import com.pexip.sdk.media.VideoTrack
+import kotlinx.coroutines.CompletableJob
 import org.webrtc.CapturerObserver
 import org.webrtc.EglBase
 import org.webrtc.JavaI420Buffer
@@ -41,6 +42,7 @@ internal open class WebRtcLocalVideoTrack(
     internal val videoTrack: org.webrtc.VideoTrack,
     protected val workerExecutor: Executor,
     protected val signalingExecutor: Executor,
+    private val job: CompletableJob,
 ) : LocalVideoTrack, VideoTrack by WebRtcVideoTrack(videoTrack) {
 
     private val disposed = AtomicBoolean()
@@ -167,6 +169,7 @@ internal open class WebRtcLocalVideoTrack(
                 videoSource.dispose()
                 videoCapturer.dispose()
                 textureHelper.dispose()
+                job.complete()
             }
         }
     }

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
@@ -28,6 +28,7 @@ import com.pexip.sdk.media.VideoTrack
 import com.pexip.sdk.media.coroutines.getCapturing
 import com.pexip.sdk.media.webrtc.WebRtcMediaConnectionFactory
 import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -62,13 +63,14 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal class WebRtcMediaConnection(
     factory: WebRtcMediaConnectionFactory,
     private val config: MediaConnectionConfig,
+    dispatcher: CoroutineDispatcher,
     private val job: CompletableJob,
 ) : MediaConnection {
 
     private val started = AtomicBoolean()
     private val shouldAck = AtomicBoolean(true)
 
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+    private val scope = CoroutineScope(SupervisorJob() + dispatcher)
     private val wrapper = factory.createPeerConnection(config)
 
     private val maxBitrate = MutableStateFlow(0.bps)


### PR DESCRIPTION
Note that `PeerConnectionWrapper` now assumes that it will be used from
a single thread and doesn't make any attempts to protect a handful of
properties from concurrent access.
