### PR TITLE
fix(media): switch Executors with CoroutineScopes

### DIFF
--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
@@ -19,44 +19,59 @@ import android.content.Context
 import com.pexip.sdk.media.LocalAudioTrack
 import com.pexip.sdk.media.LocalMediaTrack
 import kotlinx.coroutines.CompletableJob
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.webrtc.AudioSource
 import org.webrtc.AudioTrack
 import java.util.concurrent.CopyOnWriteArraySet
-import java.util.concurrent.Executor
-import java.util.concurrent.atomic.AtomicBoolean
 
 internal class WebRtcLocalAudioTrack(
     context: Context,
     private val audioSource: AudioSource,
     internal val audioTrack: AudioTrack,
-    private val workerExecutor: Executor,
-    private val signalingExecutor: Executor,
+    workerDispatcher: CoroutineDispatcher,
+    signalingDispatcher: CoroutineDispatcher,
     private val job: CompletableJob,
 ) : LocalAudioTrack {
 
-    private val disposed = AtomicBoolean()
+    private val scope = CoroutineScope(SupervisorJob() + workerDispatcher)
     private val capturingListeners = CopyOnWriteArraySet<LocalMediaTrack.CapturingListener>()
     private val microphoneMuteObserver = MicrophoneMuteObserver(context) { microphoneMute ->
-        signalingExecutor.maybeExecute {
-            capturingListeners.forEach {
-                it.safeOnCapturing(!microphoneMute)
-            }
+        scope.launch(signalingDispatcher) {
+            capturingListeners.forEach { it.safeOnCapturing(!microphoneMute) }
         }
     }
 
     override val capturing: Boolean
         get() = !microphoneMuteObserver.microphoneMute
 
-    override fun startCapture() {
-        workerExecutor.maybeExecute {
-            microphoneMuteObserver.microphoneMute = false
+    init {
+        scope.launch {
+            try {
+                awaitCancellation()
+            } finally {
+                withContext(NonCancellable) {
+                    microphoneMuteObserver.dispose()
+                    audioTrack.dispose()
+                    audioSource.dispose()
+                    job.complete()
+                }
+            }
         }
     }
 
+    override fun startCapture() {
+        scope.launch { microphoneMuteObserver.microphoneMute = false }
+    }
+
     override fun stopCapture() {
-        workerExecutor.maybeExecute {
-            microphoneMuteObserver.microphoneMute = true
-        }
+        scope.launch { microphoneMuteObserver.microphoneMute = true }
     }
 
     override fun registerCapturingListener(listener: LocalMediaTrack.CapturingListener) {
@@ -68,13 +83,6 @@ internal class WebRtcLocalAudioTrack(
     }
 
     override fun dispose() {
-        if (disposed.compareAndSet(false, true)) {
-            workerExecutor.execute {
-                microphoneMuteObserver.dispose()
-                audioTrack.dispose()
-                audioSource.dispose()
-                job.complete()
-            }
-        }
+        scope.cancel()
     }
 }

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
@@ -57,6 +57,7 @@ internal class WebRtcLocalAudioTrack(
                 awaitCancellation()
             } finally {
                 withContext(NonCancellable) {
+                    capturingListeners.clear()
                     microphoneMuteObserver.dispose()
                     audioTrack.dispose()
                     audioSource.dispose()

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
@@ -140,6 +140,7 @@ internal open class WebRtcLocalVideoTrack(
                 awaitCancellation()
             } finally {
                 withContext(NonCancellable) {
+                    capturingListeners.clear()
                     videoCapturer.stopCapture()
                     videoTrack.dispose()
                     videoSource.dispose()

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcVideoTrack.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pexip AS
+ * Copyright 2022-2023 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,18 +17,22 @@ package com.pexip.sdk.media.webrtc.internal
 
 import com.pexip.sdk.media.Renderer
 import com.pexip.sdk.media.VideoTrack
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import org.webrtc.VideoSink
 
-@JvmInline
-internal value class WebRtcVideoTrack(private val videoTrack: org.webrtc.VideoTrack) : VideoTrack {
+internal class WebRtcVideoTrack(
+    private val videoTrack: org.webrtc.VideoTrack,
+    private val scope: CoroutineScope,
+) : VideoTrack {
 
     override fun addRenderer(renderer: Renderer) {
         require(renderer is VideoSink) { "renderer must be an instance of VideoSink." }
-        videoTrack.addSink(renderer)
+        scope.launch { videoTrack.addSink(renderer) }
     }
 
     override fun removeRenderer(renderer: Renderer) {
         require(renderer is VideoSink) { "renderer must be an instance of VideoSink." }
-        videoTrack.removeSink(renderer)
+        scope.launch { videoTrack.removeSink(renderer) }
     }
 }


### PR DESCRIPTION
This should additionally fix a rather rare, but still annoying crash when a `Renderer` is being removed, but the underlying `VideoTrack` was already disposed.

Unlike other methods in `MediaStreamTrack`, [`removeSink`](https://webrtc.googlesource.com/src/+/refs/heads/main/sdk/android/api/org/webrtc/VideoTrack.java#49) does not check if the `VideoTrack` still exists and attempts to remove and free `VideoSink` through JNI, which happily blows up (after all, the `VideoTrack` has already been disposed).
