### PR TITLE
refactor(media): share a parent Job between children of MediaConnectionFactory

### DIFF
--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
@@ -18,8 +18,8 @@ package com.pexip.sdk.media.webrtc.internal
 import android.content.Context
 import com.pexip.sdk.media.CameraVideoTrack
 import com.pexip.sdk.media.CameraVideoTrackFactory
-import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.webrtc.CameraVideoCapturer
@@ -38,18 +38,16 @@ internal class WebRtcCameraVideoTrack(
     private val videoCapturer: CameraVideoCapturer,
     videoSource: VideoSource,
     videoTrack: VideoTrack,
-    workerDispatcher: CoroutineDispatcher,
+    scope: CoroutineScope,
     signalingDispatcher: CoroutineDispatcher,
-    job: CompletableJob,
 ) : CameraVideoTrack, WebRtcLocalVideoTrack(
     applicationContext = applicationContext,
     eglBase = eglBase,
     videoCapturer = videoCapturer,
     videoSource = videoSource,
     videoTrack = videoTrack,
-    workerDispatcher = workerDispatcher,
+    scope = scope,
     signalingDispatcher = signalingDispatcher,
-    job = job,
 ) {
 
     override fun switchCamera(callback: CameraVideoTrack.SwitchCameraCallback) {

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
@@ -18,11 +18,9 @@ package com.pexip.sdk.media.webrtc.internal
 import android.content.Context
 import com.pexip.sdk.media.LocalAudioTrack
 import com.pexip.sdk.media.LocalMediaTrack
-import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
@@ -35,12 +33,10 @@ internal class WebRtcLocalAudioTrack(
     context: Context,
     private val audioSource: AudioSource,
     internal val audioTrack: AudioTrack,
-    workerDispatcher: CoroutineDispatcher,
+    private val scope: CoroutineScope,
     signalingDispatcher: CoroutineDispatcher,
-    private val job: CompletableJob,
 ) : LocalAudioTrack {
 
-    private val scope = CoroutineScope(SupervisorJob() + workerDispatcher)
     private val capturingListeners = CopyOnWriteArraySet<LocalMediaTrack.CapturingListener>()
     private val microphoneMuteObserver = MicrophoneMuteObserver(context) { microphoneMute ->
         scope.launch(signalingDispatcher) {
@@ -61,7 +57,6 @@ internal class WebRtcLocalAudioTrack(
                     microphoneMuteObserver.dispose()
                     audioTrack.dispose()
                     audioSource.dispose()
-                    job.complete()
                 }
             }
         }

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
@@ -20,11 +20,9 @@ import com.pexip.sdk.media.LocalMediaTrack
 import com.pexip.sdk.media.LocalVideoTrack
 import com.pexip.sdk.media.QualityProfile
 import com.pexip.sdk.media.VideoTrack
-import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
@@ -46,10 +44,8 @@ internal open class WebRtcLocalVideoTrack(
     private val videoCapturer: VideoCapturer,
     private val videoSource: VideoSource,
     internal val videoTrack: org.webrtc.VideoTrack,
-    workerDispatcher: CoroutineDispatcher,
+    protected val scope: CoroutineScope,
     protected val signalingDispatcher: CoroutineDispatcher,
-    protected val scope: CoroutineScope = CoroutineScope(SupervisorJob() + workerDispatcher),
-    private val job: CompletableJob,
 ) : LocalVideoTrack, VideoTrack by WebRtcVideoTrack(videoTrack, scope) {
 
     private val capturingListeners = CopyOnWriteArraySet<LocalMediaTrack.CapturingListener>()
@@ -146,7 +142,6 @@ internal open class WebRtcLocalVideoTrack(
                     videoSource.dispose()
                     videoCapturer.dispose()
                     textureHelper.dispose()
-                    job.complete()
                 }
             }
         }

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
@@ -27,12 +27,10 @@ import com.pexip.sdk.media.MediaConnectionSignaling
 import com.pexip.sdk.media.VideoTrack
 import com.pexip.sdk.media.coroutines.getCapturing
 import com.pexip.sdk.media.webrtc.WebRtcMediaConnectionFactory
-import kotlinx.coroutines.CompletableJob
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.NonCancellable
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
@@ -62,15 +60,13 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal class WebRtcMediaConnection(
     factory: WebRtcMediaConnectionFactory,
     private val config: MediaConnectionConfig,
-    workerDispatcher: CoroutineDispatcher,
+    private val scope: CoroutineScope,
     private val signalingDispatcher: CoroutineDispatcher,
-    private val job: CompletableJob,
 ) : MediaConnection {
 
     private val started = AtomicBoolean()
     private val shouldAck = AtomicBoolean(true)
 
-    private val scope = CoroutineScope(SupervisorJob() + workerDispatcher)
     private val wrapper = factory.createPeerConnection(config)
 
     private val maxBitrate = MutableStateFlow(0.bps)
@@ -362,7 +358,6 @@ internal class WebRtcMediaConnection(
                 mainRemoteVideoTrackListeners.clear()
                 presentationRemoteVideoTrackListeners.clear()
                 wrapper.dispose()
-                job.complete()
             }
         }
     }


### PR DESCRIPTION
Instead of making sure all the children complete before `dispose()` is called, we'll instead cancel their parent `Job`.
