### PR TITLE
feat(api): add RequestTokenRequest.registrationToken

### DIFF
--- a/sdk-api-infinity/api/sdk-api-infinity.api
+++ b/sdk-api-infinity/api/sdk-api-infinity.api
@@ -754,20 +754,22 @@ public final class com/pexip/sdk/api/infinity/RequestRegistrationTokenResponse$C
 public final class com/pexip/sdk/api/infinity/RequestTokenRequest {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/RequestTokenRequest$Companion;
 	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3-BqYgc20 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
-	public final fun copy-pAoC41U (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/RequestTokenRequest;
-	public static synthetic fun copy-pAoC41U$default (Lcom/pexip/sdk/api/infinity/RequestTokenRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/RequestTokenRequest;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun copy-sAzET1M (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/RequestTokenRequest;
+	public static synthetic fun copy-sAzET1M$default (Lcom/pexip/sdk/api/infinity/RequestTokenRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/RequestTokenRequest;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChosenIdp-BqYgc20 ()Ljava/lang/String;
 	public final fun getConferenceExtension ()Ljava/lang/String;
 	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getIncomingToken ()Ljava/lang/String;
+	public final fun getRegistrationToken ()Ljava/lang/String;
 	public final fun getSsoToken ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/RequestTokenRequest.kt
+++ b/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/RequestTokenRequest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pexip AS
+ * Copyright 2022-2023 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,4 +31,6 @@ public data class RequestTokenRequest(
     public val ssoToken: String? = null,
     @Transient
     public val incomingToken: String? = null,
+    @Transient
+    public val registrationToken: String? = null,
 )

--- a/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RealConferenceStep.kt
+++ b/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RealConferenceStep.kt
@@ -55,6 +55,8 @@ internal class RealConferenceStep(
             }
         if (request.incomingToken?.isNotBlank() == true) {
             builder.header("token", request.incomingToken)
+        } else if (request.registrationToken?.isNotBlank() == true) {
+            builder.header("registration_token", request.registrationToken)
         }
         return RealCall(client, builder.build(), ::parseRequestToken)
     }

--- a/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
+++ b/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
@@ -181,6 +181,7 @@ internal class ConferenceStepTest {
         val requests = setOf(
             RequestTokenRequest(ssoToken = Random.nextString(8)),
             RequestTokenRequest(incomingToken = Random.nextString(8)),
+            RequestTokenRequest(registrationToken = Random.nextString(8)),
         )
         requests.forEach {
             server.enqueue {
@@ -448,8 +449,9 @@ internal class ConferenceStepTest {
         }
         assertPin(pin)
         assertToken(request.incomingToken)
-        // Copy due to incomingToken being @Transient
-        assertPost(json, request.copy(incomingToken = null))
+        assertRegistrationToken(request.registrationToken)
+        // Copy due to incomingToken & registrationToken being @Transient
+        assertPost(json, request.copy(incomingToken = null, registrationToken = null))
     }
 
     private fun MockWebServer.verifyRefreshToken(token: String) = takeRequest {

--- a/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/Util.kt
+++ b/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/Util.kt
@@ -15,7 +15,6 @@
  */
 package com.pexip.sdk.api.infinity
 
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -70,6 +69,9 @@ internal fun RecordedRequest.assertRequestUrl(url: URL, block: HttpUrl.Builder.(
     assertEquals(url.toString().toHttpUrl().newBuilder().apply(block).build(), requestUrl)
 
 internal fun RecordedRequest.assertToken(token: String?) = assertEquals(token, getHeader("token"))
+
+internal fun RecordedRequest.assertRegistrationToken(token: String?) =
+    assertEquals(token, getHeader("registration_token"))
 
 internal fun RecordedRequest.assertAuthorization(username: String, password: String) {
     val base64 = "$username:$password".encodeUtf8().base64Url()


### PR DESCRIPTION
To exchange a registration token for conference token we must use a this header instead of `token`.
