### PR TITLE
fix(media): moved keepScreenOn outside of renderer

### DIFF
--- a/sdk-media-webrtc-compose/api/sdk-media-webrtc-compose.api
+++ b/sdk-media-webrtc-compose/api/sdk-media-webrtc-compose.api
@@ -4,6 +4,6 @@ public final class com/pexip/sdk/media/webrtc/compose/CompositionLocalsKt {
 }
 
 public final class com/pexip/sdk/media/webrtc/compose/VideoTrackRendererKt {
-	public static final fun VideoTrackRenderer (Lcom/pexip/sdk/media/VideoTrack;Landroidx/compose/ui/Modifier;ZZZLandroidx/compose/runtime/Composer;II)V
+	public static final fun VideoTrackRenderer (Lcom/pexip/sdk/media/VideoTrack;Landroidx/compose/ui/Modifier;ZZZZLandroidx/compose/runtime/Composer;II)V
 }
 

--- a/sdk-media-webrtc-compose/src/main/kotlin/com/pexip/sdk/media/webrtc/compose/VideoTrackRenderer.kt
+++ b/sdk-media-webrtc-compose/src/main/kotlin/com/pexip/sdk/media/webrtc/compose/VideoTrackRenderer.kt
@@ -34,6 +34,7 @@ import org.webrtc.GlRectDrawer
  *
  * @param videoTrack an instance of video track or null
  * @param modifier optional [Modifier] to be applied to the video
+ * @param keepScreenOn controls whether the screen should remain on
  * @param mirror defines if the video should rendered mirrored
  * @param zOrderMediaOverlay control whether the video is rendered on top of another video
  * @param zOrderOnTop control whether the video is rendered on top of its window. This overrides [zOrderMediaOverlay] if set
@@ -77,9 +78,7 @@ public fun VideoTrackRenderer(
             }
         },
         update = {
-            renderer.apply {
-                it.keepScreenOn = keepScreenOn
-            }
+            renderer.apply { it.keepScreenOn = keepScreenOn }
         },
         modifier = modifier,
     )

--- a/sdk-media-webrtc-compose/src/main/kotlin/com/pexip/sdk/media/webrtc/compose/VideoTrackRenderer.kt
+++ b/sdk-media-webrtc-compose/src/main/kotlin/com/pexip/sdk/media/webrtc/compose/VideoTrackRenderer.kt
@@ -21,7 +21,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.viewinterop.AndroidView
 import com.pexip.sdk.media.VideoTrack
 import com.pexip.sdk.media.webrtc.SurfaceViewRenderer
@@ -43,6 +42,7 @@ import org.webrtc.GlRectDrawer
 public fun VideoTrackRenderer(
     videoTrack: VideoTrack?,
     modifier: Modifier = Modifier,
+    keepScreenOn: Boolean = true,
     mirror: Boolean = false,
     zOrderMediaOverlay: Boolean = false,
     zOrderOnTop: Boolean = false,
@@ -52,7 +52,6 @@ public fun VideoTrackRenderer(
     val eglBaseConfigAttributes = LocalEglBaseConfigAttributes.current
     val context = LocalContext.current
     val renderer = remember(context) { SurfaceViewRenderer(context) }
-    val currentView = LocalView.current
     DisposableEffect(renderer, eglBaseContext) {
         renderer.init(eglBaseContext, null, eglBaseConfigAttributes, GlRectDrawer())
         onDispose {
@@ -70,17 +69,16 @@ public fun VideoTrackRenderer(
             renderer.clearImage()
         }
     }
-    DisposableEffect(currentView) {
-        currentView.keepScreenOn = true
-        onDispose {
-            currentView.keepScreenOn = false
-        }
-    }
     AndroidView(
         factory = {
             renderer.apply {
                 if (zOrderMediaOverlay) setZOrderMediaOverlay(true)
                 if (zOrderOnTop) setZOrderOnTop(true)
+            }
+        },
+        update = {
+            renderer.apply {
+                it.keepScreenOn = keepScreenOn
             }
         },
         modifier = modifier,

--- a/sdk-media-webrtc-compose/src/main/kotlin/com/pexip/sdk/media/webrtc/compose/VideoTrackRenderer.kt
+++ b/sdk-media-webrtc-compose/src/main/kotlin/com/pexip/sdk/media/webrtc/compose/VideoTrackRenderer.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.viewinterop.AndroidView
 import com.pexip.sdk.media.VideoTrack
 import com.pexip.sdk.media.webrtc.SurfaceViewRenderer
@@ -51,6 +52,7 @@ public fun VideoTrackRenderer(
     val eglBaseConfigAttributes = LocalEglBaseConfigAttributes.current
     val context = LocalContext.current
     val renderer = remember(context) { SurfaceViewRenderer(context) }
+    val currentView = LocalView.current
     DisposableEffect(renderer, eglBaseContext) {
         renderer.init(eglBaseContext, null, eglBaseConfigAttributes, GlRectDrawer())
         onDispose {
@@ -68,10 +70,15 @@ public fun VideoTrackRenderer(
             renderer.clearImage()
         }
     }
+    DisposableEffect(currentView) {
+        currentView.keepScreenOn = true
+        onDispose {
+            currentView.keepScreenOn = false
+        }
+    }
     AndroidView(
         factory = {
             renderer.apply {
-                keepScreenOn = true
                 if (zOrderMediaOverlay) setZOrderMediaOverlay(true)
                 if (zOrderOnTop) setZOrderOnTop(true)
             }

--- a/sdk-media-webrtc-compose/src/main/kotlin/com/pexip/sdk/media/webrtc/compose/VideoTrackRenderer.kt
+++ b/sdk-media-webrtc-compose/src/main/kotlin/com/pexip/sdk/media/webrtc/compose/VideoTrackRenderer.kt
@@ -77,9 +77,7 @@ public fun VideoTrackRenderer(
                 if (zOrderOnTop) setZOrderOnTop(true)
             }
         },
-        update = {
-            renderer.apply { it.keepScreenOn = keepScreenOn }
-        },
+        update = { it.keepScreenOn = keepScreenOn },
         modifier = modifier,
     )
 }


### PR DESCRIPTION
The `keepScreenOn` inside AndroidView is not working for me, neither in the SampleApp or in the apps using the SDK. So I moved it to a disposableEffect instead, which seems to work fine.