### PR TITLE
feat: bump compileSdk to 34

### DIFF
--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/internal/Android.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/internal/Android.kt
@@ -21,7 +21,7 @@ internal object Android {
 
     const val minSdk = 21
     const val targetSdk = 33
-    const val compileSdk = 33
+    const val compileSdk = 34
 
     const val testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 


### PR DESCRIPTION
`targetSdk` will be bumped a bit later (only affects the sample app) as it requires a few `Service`-related changes.
