### PR TITLE
fix(api): registration_token as JSON property

### DIFF
--- a/sdk-api-infinity/api/sdk-api-infinity.api
+++ b/sdk-api-infinity/api/sdk-api-infinity.api
@@ -753,7 +753,7 @@ public final class com/pexip/sdk/api/infinity/RequestRegistrationTokenResponse$C
 
 public final class com/pexip/sdk/api/infinity/RequestTokenRequest {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/RequestTokenRequest$Companion;
-	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (ILjava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;

--- a/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/RequestTokenRequest.kt
+++ b/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/RequestTokenRequest.kt
@@ -31,6 +31,6 @@ public data class RequestTokenRequest(
     public val ssoToken: String? = null,
     @Transient
     public val incomingToken: String? = null,
-    @Transient
+    @SerialName("registration_token")
     public val registrationToken: String? = null,
 )

--- a/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
+++ b/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
@@ -449,9 +449,8 @@ internal class ConferenceStepTest {
         }
         assertPin(pin)
         assertToken(request.incomingToken)
-        assertRegistrationToken(request.registrationToken)
-        // Copy due to incomingToken & registrationToken being @Transient
-        assertPost(json, request.copy(incomingToken = null, registrationToken = null))
+        // Copy due to incomingToken being @Transient
+        assertPost(json, request.copy(incomingToken = null))
     }
 
     private fun MockWebServer.verifyRefreshToken(token: String) = takeRequest {

--- a/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/Util.kt
+++ b/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/Util.kt
@@ -70,9 +70,6 @@ internal fun RecordedRequest.assertRequestUrl(url: URL, block: HttpUrl.Builder.(
 
 internal fun RecordedRequest.assertToken(token: String?) = assertEquals(token, getHeader("token"))
 
-internal fun RecordedRequest.assertRegistrationToken(token: String?) =
-    assertEquals(token, getHeader("registration_token"))
-
 internal fun RecordedRequest.assertAuthorization(username: String, password: String) {
     val base64 = "$username:$password".encodeUtf8().base64Url()
     assertEquals("x-pexip-basic $base64", getHeader("Authorization"))


### PR DESCRIPTION
Due to historical reasons `registration_token` cannot be used as a header and must be provided in the body instead.
