### PR TITLE
fix(api): handle a different update response form for direct media

### DIFF
--- a/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/internal/UnboxingSerializer.kt
+++ b/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/internal/UnboxingSerializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pexip AS
+ * Copyright 2022-2023 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,6 @@ import kotlinx.serialization.json.jsonObject
 internal abstract class UnboxingSerializer<T : Any>(tSerializer: KSerializer<T>) :
     JsonTransformingSerializer<T>(tSerializer) {
 
-    final override fun transformDeserialize(element: JsonElement): JsonElement =
+    override fun transformDeserialize(element: JsonElement): JsonElement =
         element.jsonObject.getValue("result")
 }

--- a/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/internal/UpdateResponseSerializer.kt
+++ b/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/internal/UpdateResponseSerializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pexip AS
+ * Copyright 2022-2023 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,6 +16,18 @@
 package com.pexip.sdk.api.infinity.internal
 
 import com.pexip.sdk.api.infinity.UpdateResponse
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 
 internal object UpdateResponseSerializer :
-    UnboxingSerializer<UpdateResponse>(UpdateResponse.serializer())
+    UnboxingSerializer<UpdateResponse>(UpdateResponse.serializer()) {
+
+    override fun transformDeserialize(element: JsonElement): JsonElement =
+        when (val e = super.transformDeserialize(element)) {
+            is JsonPrimitive -> e
+            is JsonObject -> e.getValue("sdp")
+            else -> throw SerializationException()
+        }
+}

--- a/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/internal/UpdateResponseSerializerTest.kt
+++ b/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/internal/UpdateResponseSerializerTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.api.infinity.internal
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.tableOf
+import com.pexip.sdk.api.infinity.UpdateResponse
+import kotlinx.serialization.json.Json
+import okio.BufferedSource
+import okio.FileSystem
+import okio.Path.Companion.toPath
+import kotlin.test.Test
+
+class UpdateResponseSerializerTest {
+
+    @Test
+    fun `correctly deserializes update response`() {
+        val json = Json {
+            ignoreUnknownKeys = true
+            coerceInputValues = true
+        }
+        tableOf("filename", "sdp")
+            .row("update_response.json", "uqbNGpd1u4")
+            .row("update_response_direct_media.json", "D7ZanzX2QK")
+            .forAll { filename, sdp ->
+                val content = FileSystem.RESOURCES.read(filename.toPath(), BufferedSource::readUtf8)
+                val response = json.decodeFromString(UpdateResponseSerializer, content)
+                assertThat(UpdateResponse(sdp), "sdp").isEqualTo(response)
+            }
+    }
+}

--- a/sdk-api-infinity/src/test/resources/update_response.json
+++ b/sdk-api-infinity/src/test/resources/update_response.json
@@ -1,0 +1,3 @@
+{
+  "result": "uqbNGpd1u4"
+}

--- a/sdk-api-infinity/src/test/resources/update_response_direct_media.json
+++ b/sdk-api-infinity/src/test/resources/update_response_direct_media.json
@@ -1,0 +1,6 @@
+{
+  "result": {
+    "call_uuid": "6eb43cd2-2c59-4fa7-8889-37ae4d73b423",
+    "sdp": "D7ZanzX2QK"
+  }
+}


### PR DESCRIPTION
It appears that a transcoded call response contains SDP as a plain String, while direct media call includes a JSON object instead.
