### PR TITLE
refactor(conference): use raw events and map later

### DIFF
--- a/sdk-conference-infinity/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ConferenceEvent.kt
+++ b/sdk-conference-infinity/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ConferenceEvent.kt
@@ -16,28 +16,19 @@
 package com.pexip.sdk.conference.infinity.internal
 
 import com.pexip.sdk.api.Event
-import com.pexip.sdk.api.coroutines.asFlow
 import com.pexip.sdk.api.infinity.DisconnectEvent
-import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.MessageReceivedEvent
 import com.pexip.sdk.api.infinity.PresentationStartEvent
 import com.pexip.sdk.api.infinity.PresentationStopEvent
 import com.pexip.sdk.api.infinity.ReferEvent
-import com.pexip.sdk.api.infinity.TokenStore
 import com.pexip.sdk.conference.DisconnectConferenceEvent
 import com.pexip.sdk.conference.FailureConferenceEvent
 import com.pexip.sdk.conference.MessageReceivedConferenceEvent
 import com.pexip.sdk.conference.PresentationStartConferenceEvent
 import com.pexip.sdk.conference.PresentationStopConferenceEvent
 import com.pexip.sdk.conference.ReferConferenceEvent
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.mapNotNull
-import kotlinx.coroutines.flow.retryWhen
-import kotlin.time.Duration.Companion.seconds
 
+@Suppress("ktlint:standard:function-naming")
 internal inline fun ConferenceEvent(
     event: Event,
     at: () -> Long = System::currentTimeMillis,
@@ -67,17 +58,6 @@ internal inline fun ConferenceEvent(
     else -> null
 }
 
+@Suppress("ktlint:standard:function-naming")
 internal inline fun ConferenceEvent(t: Throwable, at: () -> Long = System::currentTimeMillis) =
     FailureConferenceEvent(at(), t)
-
-@OptIn(ExperimentalCoroutinesApi::class)
-internal fun InfinityService.ConferenceStep.conferenceEvent(
-    store: TokenStore,
-    at: () -> Long = System::currentTimeMillis,
-) = flow { emit(store.get()) }
-    .flatMapLatest { events(it).asFlow() }
-    .mapNotNull { ConferenceEvent(it, at) }
-    .retryWhen { _, attempt ->
-        delay(attempt.seconds.coerceAtMost(5.seconds))
-        true
-    }

--- a/sdk-conference-infinity/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/Events.kt
+++ b/sdk-conference-infinity/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/Events.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2023 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.conference.infinity.internal
+
+import com.pexip.sdk.api.coroutines.asFlow
+import com.pexip.sdk.api.infinity.InfinityService
+import com.pexip.sdk.api.infinity.TokenStore
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.retryWhen
+import kotlin.time.Duration.Companion.seconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal fun InfinityService.ConferenceStep.events(store: TokenStore) = flow { emit(store.get()) }
+    .flatMapLatest { events(it).asFlow() }
+    .retryWhen { _, attempt ->
+        delay(attempt.seconds.coerceAtMost(5.seconds))
+        true
+    }

--- a/sdk-conference-infinity/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/EventsTest.kt
+++ b/sdk-conference-infinity/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/EventsTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.conference.infinity.internal
+
+import app.cash.turbine.test
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.pexip.sdk.api.Event
+import com.pexip.sdk.api.EventSource
+import com.pexip.sdk.api.EventSourceFactory
+import com.pexip.sdk.api.EventSourceListener
+import com.pexip.sdk.api.infinity.Token
+import com.pexip.sdk.api.infinity.TokenStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.random.Random
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class EventsTest {
+
+    private lateinit var event: MutableSharedFlow<Result<Event>>
+    private lateinit var store: TokenStore
+
+    @BeforeTest
+    fun setUp() {
+        event = MutableSharedFlow()
+        store = TokenStore.create(Random.nextToken())
+    }
+
+    @Test
+    fun `maps Event to ConferenceEvent`() = runTest {
+        val step = testConferenceStep()
+        step.events(store).test {
+            event.awaitSubscribers()
+            val events = List(10) { TestEvent() }
+            events.forEach {
+                event.emit(Result.success(it))
+                assertThat(awaitItem(), "event").isEqualTo(it)
+            }
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `failure restarts the flow`() = runTest {
+        val step = testConferenceStep()
+        step.events(store).test {
+            event.awaitSubscribers()
+            val event1 = TestEvent()
+            event.emit(Result.success(event1))
+            assertThat(awaitItem(), "event").isEqualTo(event1)
+            event.emit(Result.failure(Throwable()))
+            event.awaitSubscribers()
+            val event2 = TestEvent()
+            event.emit(Result.success(event2))
+            assertThat(awaitItem(), "event").isEqualTo(event2)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private suspend fun <T> MutableSharedFlow<T>.awaitSubscribers() {
+        subscriptionCount.first { it > 0 }
+    }
+
+    private fun TestScope.testConferenceStep() = object : TestConferenceStep() {
+
+        override fun events(token: Token): EventSourceFactory {
+            assertThat(token, "token").isEqualTo(store.get())
+            return TestEventSourceFactory(backgroundScope, event)
+        }
+    }
+
+    private class TestEventSourceFactory(
+        private val scope: CoroutineScope,
+        private val event: Flow<Result<Event>>,
+    ) : EventSourceFactory {
+
+        override fun create(listener: EventSourceListener): EventSource =
+            TestEventSource(scope, event, listener)
+    }
+
+    private class TestEventSource(
+        scope: CoroutineScope,
+        event: Flow<Result<Event>>,
+        listener: EventSourceListener,
+    ) : EventSource {
+
+        private val job = event
+            .onEach {
+                it.fold(
+                    onSuccess = { event -> listener.onEvent(this, event) },
+                    onFailure = { t -> listener.onClosed(this, t) },
+                )
+            }
+            .launchIn(scope)
+
+        override fun cancel(): Unit = job.cancel()
+    }
+
+    private class TestEvent : Event
+}


### PR DESCRIPTION
We'll need to pass a few things down through signaling instead, and this will remove the need to have additional `ConferenceEvent`s
