### PR TITLE
feat(api,conference): add directMediaRequested property

### DIFF
--- a/sdk-api-infinity/api/sdk-api-infinity.api
+++ b/sdk-api-infinity/api/sdk-api-infinity.api
@@ -912,8 +912,8 @@ public final class com/pexip/sdk/api/infinity/RequestTokenRequest$Companion {
 public final class com/pexip/sdk/api/infinity/RequestTokenResponse : com/pexip/sdk/api/infinity/Token {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/RequestTokenResponse$Companion;
 	public synthetic fun <init> (ILjava/lang/String;JLjava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZLjava/lang/Integer;Lkotlin/time/Duration;Lkotlinx/serialization/internal/SerializationConstructorMarker;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZLjava/lang/Integer;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZLjava/lang/Integer;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZLjava/lang/Integer;JZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZLjava/lang/Integer;JZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Lcom/pexip/sdk/api/infinity/ServiceType;
 	public final fun component11 ()Ljava/util/List;
@@ -922,6 +922,7 @@ public final class com/pexip/sdk/api/infinity/RequestTokenResponse : com/pexip/s
 	public final fun component14 ()Z
 	public final fun component15 ()Ljava/lang/Integer;
 	public final fun component16-UwyO8pc ()J
+	public final fun component17 ()Z
 	public final fun component2 ()J
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/util/UUID;
@@ -930,8 +931,8 @@ public final class com/pexip/sdk/api/infinity/RequestTokenResponse : com/pexip/s
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Z
-	public final fun copy-01_5YiM (Ljava/lang/String;JLjava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZLjava/lang/Integer;J)Lcom/pexip/sdk/api/infinity/RequestTokenResponse;
-	public static synthetic fun copy-01_5YiM$default (Lcom/pexip/sdk/api/infinity/RequestTokenResponse;Ljava/lang/String;JLjava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZLjava/lang/Integer;JILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/RequestTokenResponse;
+	public final fun copy-pgF73Fw (Ljava/lang/String;JLjava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZLjava/lang/Integer;JZ)Lcom/pexip/sdk/api/infinity/RequestTokenResponse;
+	public static synthetic fun copy-pgF73Fw$default (Lcom/pexip/sdk/api/infinity/RequestTokenResponse;Ljava/lang/String;JLjava/lang/String;Ljava/util/UUID;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZLjava/lang/Integer;JZILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/RequestTokenResponse;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAnalyticsEnabled ()Z
 	public final fun getChatEnabled ()Z
@@ -939,6 +940,7 @@ public final class com/pexip/sdk/api/infinity/RequestTokenResponse : com/pexip/s
 	public final fun getConferenceName ()Ljava/lang/String;
 	public final fun getDataChannelId ()Ljava/lang/Integer;
 	public final fun getDirectMedia ()Z
+	public final fun getDirectMediaRequested ()Z
 	public fun getExpires ()J
 	public final fun getGuestsCanPresent ()Z
 	public final fun getParticipantId ()Ljava/util/UUID;

--- a/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/RequestTokenResponse.kt
+++ b/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/RequestTokenResponse.kt
@@ -19,6 +19,7 @@ import com.pexip.sdk.api.infinity.internal.DurationAsMillisecondsSerializer
 import com.pexip.sdk.api.infinity.internal.UUIDSerializer
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.Transient
 import kotlinx.serialization.builtins.LongAsStringSerializer
 import java.util.UUID
 import kotlin.time.Duration
@@ -55,4 +56,6 @@ public data class RequestTokenResponse(
     @Serializable(with = DurationAsMillisecondsSerializer::class)
     @SerialName("client_stats_update_interval")
     public val clientStatsUpdateInterval: Duration = Duration.INFINITE,
+    @Transient
+    public val directMediaRequested: Boolean = false,
 ) : Token

--- a/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
+++ b/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
@@ -51,6 +51,7 @@ internal class ConferenceStepImpl(
                 conference(conferenceAlias)
                 addPathSegment("request_token")
             }
+            .withTag(request.directMedia)
             .build(),
         mapper = ::parseRequestToken,
     )
@@ -66,6 +67,7 @@ internal class ConferenceStepImpl(
                 conference(conferenceAlias)
                 addPathSegment("request_token")
             }
+            .withTag(request.directMedia)
             .header("pin", if (pin.isBlank()) "none" else pin.trim())
             .build(),
         mapper = ::parseRequestToken,
@@ -148,7 +150,11 @@ internal class ConferenceStepImpl(
         ParticipantStepImpl(this, participantId)
 
     private fun parseRequestToken(response: Response) = when (response.code) {
-        200 -> json.decodeFromResponseBody(RequestTokenResponseSerializer, response.body!!)
+        200 -> {
+            val r = json.decodeFromResponseBody(RequestTokenResponseSerializer, response.body!!)
+            val directMediaRequested = response.request.tagOrElse { false }
+            r.copy(directMediaRequested = directMediaRequested)
+        }
         403 -> response.parseRequestToken403()
         404 -> response.parse404()
         else -> throw IllegalStateException()

--- a/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/internal/Util.kt
+++ b/sdk-api-infinity/src/main/kotlin/com/pexip/sdk/api/infinity/internal/Util.kt
@@ -71,4 +71,9 @@ internal inline fun Request.Builder.url(
     return url(builder.apply(block).build())
 }
 
+internal inline fun <reified T : Any> Request.Builder.withTag(tag: T?) = tag(T::class.java, tag)
+
+internal inline fun <reified T : Any> Request.tagOrElse(block: () -> T) =
+    tag(T::class.java) ?: block()
+
 private val ApplicationJson by lazy { "application/json; charset=utf-8".toMediaType() }

--- a/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
+++ b/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
@@ -50,7 +50,7 @@ internal class ConferenceStepTest {
     fun setUp() {
         node = server.url("/").toUrl()
         conferenceAlias = Random.nextString(8)
-        json = Json { ignoreUnknownKeys = true }
+        json = InfinityService.Json
         val service = InfinityService.create(OkHttpClient(), json)
         step = service.newRequest(node).conference(conferenceAlias)
     }
@@ -197,9 +197,18 @@ internal class ConferenceStepTest {
             clientStatsUpdateInterval = Random.nextDuration(),
         )
         val requests = setOf(
-            RequestTokenRequest(ssoToken = Random.nextString(8)),
-            RequestTokenRequest(incomingToken = Random.nextString(8)),
-            RequestTokenRequest(registrationToken = Random.nextString(8)),
+            RequestTokenRequest(
+                ssoToken = Random.nextString(8),
+                directMedia = response.directMediaRequested,
+            ),
+            RequestTokenRequest(
+                incomingToken = Random.nextString(8),
+                directMedia = response.directMediaRequested,
+            ),
+            RequestTokenRequest(
+                registrationToken = Random.nextString(8),
+                directMedia = response.directMediaRequested,
+            ),
         )
         requests.forEach {
             server.enqueue {
@@ -237,13 +246,20 @@ internal class ConferenceStepTest {
                 )
             },
             directMedia = Random.nextBoolean(),
+            directMediaRequested = Random.nextBoolean(),
             useRelayCandidatesOnly = Random.nextBoolean(),
             dataChannelId = if (Random.nextBoolean()) Random.nextInt() else null,
             clientStatsUpdateInterval = Random.nextDuration(),
         )
         val requests = setOf(
-            RequestTokenRequest(ssoToken = Random.nextString(8)),
-            RequestTokenRequest(incomingToken = Random.nextString(8)),
+            RequestTokenRequest(
+                ssoToken = Random.nextString(8),
+                directMedia = response.directMediaRequested,
+            ),
+            RequestTokenRequest(
+                incomingToken = Random.nextString(8),
+                directMedia = response.directMediaRequested,
+            ),
         )
         requests.forEach {
             server.enqueue {
@@ -282,6 +298,7 @@ internal class ConferenceStepTest {
                 )
             },
             directMedia = Random.nextBoolean(),
+            directMediaRequested = Random.nextBoolean(),
             useRelayCandidatesOnly = Random.nextBoolean(),
             dataChannelId = if (Random.nextBoolean()) Random.nextInt() else null,
             clientStatsUpdateInterval = Random.nextDuration(),
@@ -290,7 +307,7 @@ internal class ConferenceStepTest {
             setResponseCode(200)
             setBody(json.encodeToString(Box(response)))
         }
-        val request = RequestTokenRequest()
+        val request = RequestTokenRequest(directMedia = response.directMediaRequested)
         val pin = "   "
         assertThat(step.requestToken(request, pin).execute(), "response").isEqualTo(response)
         server.verifyRequestToken(request, pin)

--- a/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
+++ b/sdk-api-infinity/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
@@ -192,6 +192,7 @@ internal class ConferenceStepTest {
                 )
             },
             directMedia = Random.nextBoolean(),
+            directMediaRequested = Random.nextBoolean(),
             useRelayCandidatesOnly = Random.nextBoolean(),
             dataChannelId = if (Random.nextBoolean()) Random.nextInt() else null,
             clientStatsUpdateInterval = Random.nextDuration(),

--- a/sdk-conference-infinity/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
+++ b/sdk-conference-infinity/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
@@ -75,7 +75,7 @@ public class InfinityConference private constructor(
 
     override val name: String = response.conferenceName
 
-    override val referer: Referer = RefererImpl(step.requestBuilder)
+    override val referer: Referer = RefererImpl(step.requestBuilder, response.directMediaRequested)
 
     override val messenger: Messenger = messengerImpl
 

--- a/sdk-conference-infinity/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RefererImpl.kt
+++ b/sdk-conference-infinity/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RefererImpl.kt
@@ -28,17 +28,19 @@ import kotlinx.coroutines.CancellationException
 
 internal class RefererImpl(
     private val builder: InfinityService.RequestBuilder,
+    private val directMedia: Boolean,
     private val createConference: (InfinityService.ConferenceStep, RequestTokenResponse) -> Conference,
 ) : Referer {
 
-    constructor(builder: InfinityService.RequestBuilder) : this(
+    constructor(builder: InfinityService.RequestBuilder, directMedia: Boolean) : this(
         builder = builder,
+        directMedia = directMedia,
         createConference = InfinityConference::create,
     )
 
     override suspend fun refer(event: ReferConferenceEvent): Conference = try {
         val step = builder.conference(event.conferenceAlias)
-        val request = RequestTokenRequest(incomingToken = event.token)
+        val request = RequestTokenRequest(incomingToken = event.token, directMedia = directMedia)
         val response = step.requestToken(request).await()
         createConference(step, response)
     } catch (e: CancellationException) {


### PR DESCRIPTION
This is a trick to avoid callers of `Referer.refer()` of passing `directMedia`. Instead it uses the value that the original request had.
