### PR TITLE
refactor(infinity): introduce a pre-configured Json

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
 kotlinx-serialization-json-okio = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json-okio", version.ref = "kotlinx-serialization" }
 # Dummy library for Dependabot to pick up ktlint version changes
 ktlint-cli = { module = "com.pinterest.ktlint:ktlint-cli", version.ref = "ktlint" }

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
@@ -18,8 +18,10 @@ package com.pexip.sdk.api.infinity
 import com.pexip.sdk.api.Call
 import com.pexip.sdk.api.EventSourceFactory
 import com.pexip.sdk.api.infinity.internal.InfinityServiceImpl
+import com.pexip.sdk.infinity.Infinity
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
+import kotlinx.serialization.modules.plus
 import okhttp3.OkHttpClient
 import java.net.URL
 import java.util.UUID
@@ -706,10 +708,8 @@ public interface InfinityService {
 
     public companion object {
 
-        internal val Json = Json {
-            ignoreUnknownKeys = true
-            coerceInputValues = true
-            serializersModule = SerializersModule {
+        internal val Json = Json(from = Infinity.Json) {
+            serializersModule += SerializersModule {
                 polymorphicDefaultDeserializer(ElementResponse::class) {
                     ElementResponse.Unknown.serializer()
                 }

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/CallStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/CallStepTest.kt
@@ -22,10 +22,9 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.internal.addPathSegment
+import com.pexip.sdk.infinity.Infinity
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule
 import java.net.URL
@@ -43,7 +42,6 @@ internal class CallStepTest {
     private lateinit var conferenceAlias: String
     private lateinit var participantId: UUID
     private lateinit var callId: UUID
-    private lateinit var json: Json
     private lateinit var step: InfinityService.CallStep
 
     @BeforeTest
@@ -52,8 +50,7 @@ internal class CallStepTest {
         conferenceAlias = Random.nextString(8)
         participantId = UUID.randomUUID()
         callId = UUID.randomUUID()
-        json = Json { ignoreUnknownKeys = true }
-        val service = InfinityService.create(OkHttpClient(), json)
+        val service = InfinityService.create()
         step = service.newRequest(node)
             .conference(conferenceAlias)
             .participant(participantId)
@@ -85,7 +82,7 @@ internal class CallStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val request = Random.nextNewCandidateRequest()
         val token = Random.nextString(8)
@@ -99,7 +96,7 @@ internal class CallStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val request = Random.nextNewCandidateRequest()
         val token = Random.nextString(8)
@@ -148,7 +145,7 @@ internal class CallStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         val request = Random.maybe { nextAckRequest() }
@@ -165,7 +162,7 @@ internal class CallStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         val request = Random.maybe { nextAckRequest() }
@@ -213,7 +210,7 @@ internal class CallStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         val request = Random.nextUpdateRequest()
@@ -228,7 +225,7 @@ internal class CallStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         val request = Random.nextUpdateRequest()
@@ -243,7 +240,7 @@ internal class CallStepTest {
         val response = UpdateResponse(Random.nextString(8))
         server.enqueue {
             setResponseCode(200)
-            setBody(json.encodeToString(Box(response)))
+            setBody(Infinity.Json.encodeToString(Box(response)))
         }
         val token = Random.nextString(8)
         val request = Random.nextUpdateRequest()
@@ -274,7 +271,7 @@ internal class CallStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val request = DtmfRequest(Random.nextDigits(8))
         val token = Random.nextString(8)
@@ -288,7 +285,7 @@ internal class CallStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val request = DtmfRequest(Random.nextDigits(8))
         val token = Random.nextString(8)
@@ -301,7 +298,7 @@ internal class CallStepTest {
         val response = Random.nextBoolean()
         server.enqueue {
             setResponseCode(200)
-            setBody(json.encodeToString(Box(response)))
+            setBody(Infinity.Json.encodeToString(Box(response)))
         }
         val request = DtmfRequest(Random.nextDigits(8))
         val token = Random.nextString(8)
@@ -324,7 +321,7 @@ internal class CallStepTest {
             addPathSegment("new_candidate")
         }
         assertToken(token)
-        assertPost(json, request)
+        assertPost(Infinity.Json, request)
     }
 
     private fun MockWebServer.verifyAck(request: AckRequest?, token: String) = takeRequest {
@@ -341,7 +338,7 @@ internal class CallStepTest {
         assertToken(token)
         when (request) {
             null -> assertPostEmptyBody()
-            else -> assertPost(json, request)
+            else -> assertPost(Infinity.Json, request)
         }
     }
 
@@ -357,7 +354,7 @@ internal class CallStepTest {
             addPathSegment("update")
         }
         assertToken(token)
-        assertPost(json, request)
+        assertPost(Infinity.Json, request)
     }
 
     private fun MockWebServer.verifyDtmf(request: DtmfRequest, token: String) = takeRequest {
@@ -372,7 +369,7 @@ internal class CallStepTest {
             addPathSegment("dtmf")
         }
         assertToken(token)
-        assertPost(json, request)
+        assertPost(Infinity.Json, request)
     }
 
     private fun Random.nextNewCandidateRequest() = NewCandidateRequest(

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ParticipantStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ParticipantStepTest.kt
@@ -16,9 +16,8 @@
 package com.pexip.sdk.api.infinity
 
 import com.pexip.sdk.api.infinity.internal.addPathSegment
+import com.pexip.sdk.infinity.Infinity
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule
 import java.net.URL
@@ -37,7 +36,6 @@ internal class ParticipantStepTest {
     private lateinit var node: URL
     private lateinit var conferenceAlias: String
     private lateinit var participantId: UUID
-    private lateinit var json: Json
     private lateinit var step: InfinityService.ParticipantStep
 
     @BeforeTest
@@ -45,8 +43,7 @@ internal class ParticipantStepTest {
         node = server.url("/").toUrl()
         conferenceAlias = Random.nextString(8)
         participantId = UUID.randomUUID()
-        json = Json { ignoreUnknownKeys = true }
-        val service = InfinityService.create(OkHttpClient(), json)
+        val service = InfinityService.create()
         step = service.newRequest(node)
             .conference(conferenceAlias)
             .participant(participantId)
@@ -75,7 +72,7 @@ internal class ParticipantStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val request = Random.nextCallsRequest()
         val token = Random.nextString(8)
@@ -88,7 +85,7 @@ internal class ParticipantStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val request = Random.nextCallsRequest()
         val token = Random.nextString(8)
@@ -104,7 +101,7 @@ internal class ParticipantStepTest {
         )
         server.enqueue {
             setResponseCode(200)
-            setBody(json.encodeToString(Box(response)))
+            setBody(Infinity.Json.encodeToString(Box(response)))
         }
         val request = Random.nextCallsRequest()
         val token = Random.nextString(8)
@@ -135,7 +132,7 @@ internal class ParticipantStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val request = DtmfRequest(Random.nextDigits(8))
         val token = Random.nextString(8)
@@ -148,7 +145,7 @@ internal class ParticipantStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val request = DtmfRequest(Random.nextDigits(8))
         val token = Random.nextString(8)
@@ -161,7 +158,7 @@ internal class ParticipantStepTest {
         val response = Random.nextBoolean()
         server.enqueue {
             setResponseCode(200)
-            setBody(json.encodeToString(Box(response)))
+            setBody(Infinity.Json.encodeToString(Box(response)))
         }
         val request = DtmfRequest(Random.nextDigits(8))
         val token = Random.nextString(8)
@@ -190,7 +187,7 @@ internal class ParticipantStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<NoSuchConferenceException> { step.mute(token).execute() }
@@ -202,7 +199,7 @@ internal class ParticipantStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<InvalidTokenException> { step.mute(token).execute() }
@@ -238,7 +235,7 @@ internal class ParticipantStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<NoSuchConferenceException> { step.unmute(token).execute() }
@@ -250,7 +247,7 @@ internal class ParticipantStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<InvalidTokenException> { step.unmute(token).execute() }
@@ -286,7 +283,7 @@ internal class ParticipantStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<NoSuchConferenceException> { step.videoMuted(token).execute() }
@@ -298,7 +295,7 @@ internal class ParticipantStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<InvalidTokenException> { step.videoMuted(token).execute() }
@@ -334,7 +331,7 @@ internal class ParticipantStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<NoSuchConferenceException> { step.videoUnmuted(token).execute() }
@@ -346,7 +343,7 @@ internal class ParticipantStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<InvalidTokenException> { step.videoUnmuted(token).execute() }
@@ -382,7 +379,7 @@ internal class ParticipantStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<NoSuchConferenceException> { step.takeFloor(token).execute() }
@@ -394,7 +391,7 @@ internal class ParticipantStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<InvalidTokenException> { step.takeFloor(token).execute() }
@@ -430,7 +427,7 @@ internal class ParticipantStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<NoSuchConferenceException> { step.releaseFloor(token).execute() }
@@ -442,7 +439,7 @@ internal class ParticipantStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<InvalidTokenException> { step.releaseFloor(token).execute() }
@@ -480,7 +477,7 @@ internal class ParticipantStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         val request = Random.nextMessageRequest()
@@ -493,7 +490,7 @@ internal class ParticipantStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         val request = Random.nextMessageRequest()
@@ -507,7 +504,7 @@ internal class ParticipantStepTest {
         results.forEach { result ->
             server.enqueue {
                 setResponseCode(200)
-                setBody(json.encodeToString(Box(result)))
+                setBody(Infinity.Json.encodeToString(Box(result)))
             }
             val token = Random.nextString(8)
             val request = Random.nextMessageRequest()
@@ -541,7 +538,7 @@ internal class ParticipantStepTest {
         val message = "Neither conference nor gateway found"
         server.enqueue {
             setResponseCode(404)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         val request = Random.nextPreferredAspectRatioRequest()
@@ -556,7 +553,7 @@ internal class ParticipantStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         val request = Random.nextPreferredAspectRatioRequest()
@@ -572,7 +569,7 @@ internal class ParticipantStepTest {
         results.forEach { result ->
             server.enqueue {
                 setResponseCode(200)
-                setBody(json.encodeToString(Box(result)))
+                setBody(Infinity.Json.encodeToString(Box(result)))
             }
             val token = Random.nextString(8)
             val request = Random.nextPreferredAspectRatioRequest()
@@ -591,7 +588,7 @@ internal class ParticipantStepTest {
             addPathSegment("calls")
         }
         assertToken(token)
-        assertPost(json, request)
+        assertPost(Infinity.Json, request)
     }
 
     private fun MockWebServer.verifyDtmf(request: DtmfRequest, token: String) = takeRequest {
@@ -604,7 +601,7 @@ internal class ParticipantStepTest {
             addPathSegment("dtmf")
         }
         assertToken(token)
-        assertPost(json, request)
+        assertPost(Infinity.Json, request)
     }
 
     private fun MockWebServer.verifyMute(token: String) = takeRequest {
@@ -696,7 +693,7 @@ internal class ParticipantStepTest {
                 addPathSegment("message")
             }
             assertToken(token)
-            assertPost(json, request)
+            assertPost(Infinity.Json, request)
         }
 
     private fun MockWebServer.verifyPreferredAspectRatio(
@@ -712,7 +709,7 @@ internal class ParticipantStepTest {
             addPathSegment("preferred_aspect_ratio")
         }
         assertToken(token)
-        assertPost(json, request)
+        assertPost(Infinity.Json, request)
     }
 
     private fun Random.nextCallsRequest() = CallsRequest(

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/RegistrationStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/RegistrationStepTest.kt
@@ -15,9 +15,8 @@
  */
 package com.pexip.sdk.api.infinity
 
+import com.pexip.sdk.infinity.Infinity
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
-import okhttp3.OkHttpClient
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule
 import java.net.URL
@@ -37,7 +36,6 @@ internal class RegistrationStepTest {
     private lateinit var deviceAlias: String
     private lateinit var username: String
     private lateinit var password: String
-    private lateinit var json: Json
     private lateinit var step: InfinityService.RegistrationStep
 
     @BeforeTest
@@ -46,8 +44,7 @@ internal class RegistrationStepTest {
         deviceAlias = Random.nextString(8)
         username = Random.nextString(8)
         password = Random.nextString(8)
-        json = Json { ignoreUnknownKeys = true }
-        val service = InfinityService.create(OkHttpClient(), json)
+        val service = InfinityService.create()
         step = service.newRequest(node).registration(deviceAlias)
     }
 
@@ -94,7 +91,7 @@ internal class RegistrationStepTest {
         )
         server.enqueue {
             setResponseCode(200)
-            setBody(json.encodeToString(Box(response)))
+            setBody(Infinity.Json.encodeToString(Box(response)))
         }
         assertEquals(response, step.requestToken(username, password).execute())
         server.verifyRequestToken()
@@ -134,7 +131,7 @@ internal class RegistrationStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         val e = assertFailsWith<InvalidTokenException> { step.refreshToken(token).execute() }
@@ -148,7 +145,7 @@ internal class RegistrationStepTest {
             token = Random.nextString(8),
             expires = 120,
         )
-        server.enqueue { setBody(json.encodeToString(Box(response))) }
+        server.enqueue { setBody(Infinity.Json.encodeToString(Box(response))) }
         val token = Random.nextString(8)
         assertEquals(response, step.refreshToken(token).execute())
         server.verifyRefreshToken(token)
@@ -188,7 +185,7 @@ internal class RegistrationStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<InvalidTokenException> { step.releaseToken(token).execute() }
@@ -200,7 +197,7 @@ internal class RegistrationStepTest {
         val result = Random.nextBoolean()
         server.enqueue {
             setResponseCode(200)
-            setBody(json.encodeToString(Box(result)))
+            setBody(Infinity.Json.encodeToString(Box(result)))
         }
         val token = Random.nextString(8)
         assertEquals(result, step.releaseToken(token).execute())
@@ -241,7 +238,7 @@ internal class RegistrationStepTest {
         val message = "Invalid token"
         server.enqueue {
             setResponseCode(403)
-            setBody(json.encodeToString(Box(message)))
+            setBody(Infinity.Json.encodeToString(Box(message)))
         }
         val token = Random.nextString(8)
         assertFailsWith<InvalidTokenException> { step.registrations(token).execute() }
@@ -262,7 +259,7 @@ internal class RegistrationStepTest {
             }
             server.enqueue {
                 setResponseCode(200)
-                setBody(json.encodeToString(Box(result)))
+                setBody(Infinity.Json.encodeToString(Box(result)))
             }
             val token = Random.nextString(8)
             assertEquals(result, step.registrations(token, query).execute())

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/EventTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/EventTest.kt
@@ -28,7 +28,6 @@ import com.pexip.sdk.api.infinity.FeccEvent
 import com.pexip.sdk.api.infinity.FeccMovement
 import com.pexip.sdk.api.infinity.IncomingCancelledEvent
 import com.pexip.sdk.api.infinity.IncomingEvent
-import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.MessageReceivedEvent
 import com.pexip.sdk.api.infinity.NewCandidateEvent
 import com.pexip.sdk.api.infinity.NewOfferEvent
@@ -39,6 +38,7 @@ import com.pexip.sdk.api.infinity.ReferEvent
 import com.pexip.sdk.api.infinity.SplashScreenEvent
 import com.pexip.sdk.api.infinity.UpdateSdpEvent
 import com.pexip.sdk.api.infinity.nextString
+import com.pexip.sdk.infinity.Infinity
 import okio.BufferedSource
 import okio.FileSystem
 import okio.Path.Companion.toPath
@@ -181,7 +181,7 @@ internal class EventTest {
             .forAll { type, filename, event ->
                 val data = FileSystem.RESOURCES.read(filename.toPath(), BufferedSource::readUtf8)
                 val actual = Event(
-                    json = InfinityService.Json,
+                    json = Infinity.Json,
                     id = Random.nextString(8),
                     type = type,
                     data = data.trim(),
@@ -193,7 +193,7 @@ internal class EventTest {
     @Test
     fun `returns null if the type is not registered`() {
         val actual = Event(
-            json = InfinityService.Json,
+            json = Infinity.Json,
             id = Random.nextString(8),
             type = Random.nextString(8),
             data = Random.nextString(8),

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/UpdateResponseSerializerTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/UpdateResponseSerializerTest.kt
@@ -18,8 +18,8 @@ package com.pexip.sdk.api.infinity.internal
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.tableOf
-import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.UpdateResponse
+import com.pexip.sdk.infinity.Infinity
 import kotlinx.serialization.json.Json
 import okio.BufferedSource
 import okio.FileSystem
@@ -33,7 +33,7 @@ class UpdateResponseSerializerTest {
 
     @BeforeTest
     fun setUp() {
-        json = InfinityService.Json
+        json = Infinity.Json
     }
 
     @Test

--- a/sdk-infinity/api/sdk-infinity.api
+++ b/sdk-infinity/api/sdk-infinity.api
@@ -1,0 +1,5 @@
+public final class com/pexip/sdk/infinity/Infinity {
+	public static final field INSTANCE Lcom/pexip/sdk/infinity/Infinity;
+	public final fun getJson ()Lkotlinx/serialization/json/Json;
+}
+

--- a/sdk-infinity/build.gradle.kts
+++ b/sdk-infinity/build.gradle.kts
@@ -1,5 +1,10 @@
 plugins {
     id("com.pexip.sdk.kotlin.jvm.publishing")
+    alias(libs.plugins.kotlin.serialization)
+}
+
+dependencies {
+    api(libs.kotlinx.serialization.json)
 }
 
 publishing.publications.withType<MavenPublication>().configureEach {

--- a/sdk-infinity/src/main/kotlin/com/pexip/sdk/infinity/Infinity.kt
+++ b/sdk-infinity/src/main/kotlin/com/pexip/sdk/infinity/Infinity.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2023 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.infinity
+
+import kotlinx.serialization.json.Json
+
+public object Infinity {
+
+    /**
+     * A pre-configured [Json] to use in tandem with Pexip Infinity REST API.
+     */
+    public val Json: Json = Json {
+        ignoreUnknownKeys = true
+        coerceInputValues = true
+    }
+}


### PR DESCRIPTION
Note that `InfinityService.Json` is still around, but will be removed after `ElementResponse` moves to `:sdk-infinity`.
