### PR TITLE
refactor: switch back to kapt

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.dagger.hilt.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
-    alias(libs.plugins.ksp) apply false
+    alias(libs.plugins.kotlin.kapt) apply false
 }
 
 group = checkNotNull(property("group")) { "group == null." }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -75,8 +75,8 @@ android-library = { id = "com.android.library", version.ref = "android" }
 dagger-hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "dagger" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlinx-binarycompatibilityvalidator = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.13.2" }
-ksp = { id = "com.google.devtools.ksp", version = "1.9.10-1.0.13" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 wire = { id = "com.squareup.wire", version.ref = "wire" }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     id("com.pexip.sdk.kotlin.android")
     id("com.pexip.sdk.licensee")
     alias(libs.plugins.dagger.hilt.android)
-    alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlin.kapt)
     alias(libs.plugins.wire)
 }
 
@@ -35,6 +35,13 @@ android {
     }
 }
 
+kapt {
+    correctErrorTypes = true
+    arguments {
+        arg("dagger.fastInit", "enabled")
+    }
+}
+
 wire {
     kotlin { }
 }
@@ -57,7 +64,7 @@ dependencies {
     implementation(libs.accompanist.systemuicontroller)
     implementation(libs.coil.compose)
     implementation(libs.dagger.hilt.android.runtime)
-    ksp(libs.dagger.hilt.compiler)
+    kapt(libs.dagger.hilt.compiler)
     implementation(libs.minidns.android21)
     implementation(libs.okhttp.logginginterceptor)
     implementation(libs.workflow.core.jvm)


### PR DESCRIPTION
Some issues with Dagger not picking up Wire-generated classes after update to Kotlin 1.9.2x
