### PR TITLE
docs(media): add a sample for simple AudioDeviceManager usage

### DIFF
--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinDokkaPlugin.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinDokkaPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Pexip AS
+ * Copyright 2023-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -44,6 +44,7 @@ class KotlinDokkaPlugin : Plugin<Project> {
         }
         tasks.withType<DokkaTaskPartial>().configureEach {
             dokkaSourceSets.configureEach {
+                samples.from("src/test/kotlin/Samples.kt")
                 includes.from("README.md")
                 externalDocumentationLink("https://kotlin.github.io/kotlinx.coroutines/")
                 noAndroidSdkLink.set(hasAndroidLibraryPluginProvider.map { !it })

--- a/sdk-media/src/main/kotlin/com/pexip/sdk/media/AudioDeviceManager.kt
+++ b/sdk-media/src/main/kotlin/com/pexip/sdk/media/AudioDeviceManager.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,6 +17,8 @@ package com.pexip.sdk.media
 
 /**
  * An audio device manager.
+ *
+ * @sample com.pexip.sdk.media.AudioDeviceManagerSample
  *
  * @property availableAudioDevices a list of available audio devices
  * @property selectedAudioDevice a currently selected audio device or null

--- a/sdk-media/src/test/kotlin/Samples.kt
+++ b/sdk-media/src/test/kotlin/Samples.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.media
+
+fun audioDeviceManagerSample(manager: AudioDeviceManager) {
+    // Get available audio devices
+    // A listener-based variant is also available to observe the changes in the list
+    val availableAudioDevices = manager.availableAudioDevices
+    // Pick the preferred audio device from the list
+    // The lower the value returned by minByOrNull, the higher the priority
+    val preferredAudioDevice = availableAudioDevices.minByOrNull {
+        when (it.type) {
+            // Prefer SCO and wired headsets over any other audio device
+            AudioDevice.Type.BLUETOOTH_SCO -> 0
+            AudioDevice.Type.WIRED_HEADSET -> 1
+            AudioDevice.Type.BUILTIN_SPEAKER -> 2
+            AudioDevice.Type.BUILTIN_EARPIECE -> 3
+            // Assign the lowest priority for A2DP since it's not suitable for VoIP
+            AudioDevice.Type.BLUETOOTH_A2DP -> Int.MAX_VALUE
+        }
+    }
+    // Ensure that there is a preferred audio device and select it
+    if (preferredAudioDevice != null) {
+        manager.selectAudioDevice(preferredAudioDevice)
+    }
+    // Once the call is finished, make sure to dispose of the AudioDeviceManager to release any
+    // resources held by it
+    manager.dispose()
+}


### PR DESCRIPTION
Run `dokka` to generate the website and see the improved docs.