### PR TITLE
refactor(media): do not require BLUETOOTH_CONNECT permission

### DIFF
--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -2,8 +2,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
 
     <application
         android:name=".SampleApplication"

--- a/sample/src/main/kotlin/com/pexip/sdk/sample/SampleWorkflow.kt
+++ b/sample/src/main/kotlin/com/pexip/sdk/sample/SampleWorkflow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package com.pexip.sdk.sample
 
 import android.Manifest
 import android.content.Context
-import android.os.Build
 import com.pexip.sdk.media.CameraVideoTrack
 import com.pexip.sdk.media.CameraVideoTrackFactory
 import com.pexip.sdk.media.LocalAudioTrack
@@ -54,11 +53,6 @@ class SampleWorkflow @Inject constructor(
     private val permissions = buildSet {
         add(Manifest.permission.RECORD_AUDIO)
         add(Manifest.permission.CAMERA)
-        if (Build.VERSION.SDK_INT >= 31) {
-            add(Manifest.permission.BLUETOOTH_CONNECT)
-        } else {
-            add(Manifest.permission.BLUETOOTH)
-        }
     }
 
     override fun initialState(props: Unit, snapshot: Snapshot?): SampleState {

--- a/sdk-media-android/src/main/AndroidManifest.xml
+++ b/sdk-media-android/src/main/AndroidManifest.xml
@@ -7,7 +7,4 @@
     <uses-permission
         android:name="android.permission.BLUETOOTH"
         android:maxSdkVersion="30" />
-
-    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
-
 </manifest>

--- a/sdk-media-android/src/main/kotlin/com/pexip/sdk/media/android/internal/BluetoothHeadsetObserver.kt
+++ b/sdk-media-android/src/main/kotlin/com/pexip/sdk/media/android/internal/BluetoothHeadsetObserver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,6 +38,7 @@ internal class BluetoothHeadsetObserver(
 
     private val filter = IntentFilter(BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED)
 
+    @Suppress("DEPRECATION")
     @SuppressLint("MissingPermission")
     private val receiver = context.registerReceiver(filter, handler) { context, intent ->
         if (context.checkBluetoothConnectPermission() == PackageManager.PERMISSION_GRANTED) {
@@ -58,6 +59,7 @@ internal class BluetoothHeadsetObserver(
         adapter?.getProfileProxy(context, this, BluetoothProfile.HEADSET)
     }
 
+    @SuppressLint("MissingPermission")
     override fun onServiceConnected(profile: Int, proxy: BluetoothProfile) {
         requireBluetoothHeadsetProfile(profile)
         this.proxy = proxy as BluetoothHeadset


### PR DESCRIPTION
`AudioManager.setCommunicationDevice()` seems to be handling most of the work and does not require this permission to connect and use a Bluetooth headset.
