### PR TITLE
feat(conference): add Theme.layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `Theme.layout` that provides the currently active layout of the conference
+
 ## [0.14.1] - 2023-02-07
 
 ### Fixed

--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -630,9 +630,41 @@ public final class com/pexip/sdk/api/infinity/InvalidTokenException : java/lang/
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public final class com/pexip/sdk/api/infinity/Layout {
-	public static final field Companion Lcom/pexip/sdk/api/infinity/Layout$Companion;
-	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/Layout;
+public final class com/pexip/sdk/api/infinity/LayoutEvent : com/pexip/sdk/api/Event {
+	public static final field Companion Lcom/pexip/sdk/api/infinity/LayoutEvent$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Lcom/pexip/sdk/api/infinity/RequestedLayout;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/pexip/sdk/api/infinity/RequestedLayout;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-09AyAb0 ()Ljava/lang/String;
+	public final fun component2 ()Lcom/pexip/sdk/api/infinity/RequestedLayout;
+	public final fun component3 ()Z
+	public final fun copy-oaHaZIw (Ljava/lang/String;Lcom/pexip/sdk/api/infinity/RequestedLayout;Z)Lcom/pexip/sdk/api/infinity/LayoutEvent;
+	public static synthetic fun copy-oaHaZIw$default (Lcom/pexip/sdk/api/infinity/LayoutEvent;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/RequestedLayout;ZILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/LayoutEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLayout-09AyAb0 ()Ljava/lang/String;
+	public final fun getOverlayTextEnabled ()Z
+	public final fun getRequestedLayout ()Lcom/pexip/sdk/api/infinity/RequestedLayout;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/pexip/sdk/api/infinity/LayoutEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/pexip/sdk/api/infinity/LayoutEvent$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/pexip/sdk/api/infinity/LayoutEvent;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/pexip/sdk/api/infinity/LayoutEvent;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/pexip/sdk/api/infinity/LayoutEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/pexip/sdk/api/infinity/LayoutId {
+	public static final field Companion Lcom/pexip/sdk/api/infinity/LayoutId$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/LayoutId;
 	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
@@ -645,18 +677,18 @@ public final class com/pexip/sdk/api/infinity/Layout {
 	public final synthetic fun unbox-impl ()Ljava/lang/String;
 }
 
-public final class com/pexip/sdk/api/infinity/Layout$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
-	public static final field INSTANCE Lcom/pexip/sdk/api/infinity/Layout$$serializer;
+public final class com/pexip/sdk/api/infinity/LayoutId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/pexip/sdk/api/infinity/LayoutId$$serializer;
 	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public fun deserialize-NgV1oZ4 (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public fun deserialize-Usdm_rY (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
 	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public fun serialize-WgIrWnY (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun serialize-tzsas1o (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
 	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/Layout$Companion {
+public final class com/pexip/sdk/api/infinity/LayoutId$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -1338,6 +1370,33 @@ public final class com/pexip/sdk/api/infinity/RequestTokenResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/pexip/sdk/api/infinity/RequestedLayout {
+	public static final field Companion Lcom/pexip/sdk/api/infinity/RequestedLayout$Companion;
+	public fun <init> (Lcom/pexip/sdk/api/infinity/Screen;)V
+	public final fun component1 ()Lcom/pexip/sdk/api/infinity/Screen;
+	public final fun copy (Lcom/pexip/sdk/api/infinity/Screen;)Lcom/pexip/sdk/api/infinity/RequestedLayout;
+	public static synthetic fun copy$default (Lcom/pexip/sdk/api/infinity/RequestedLayout;Lcom/pexip/sdk/api/infinity/Screen;ILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/RequestedLayout;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPrimaryScreen ()Lcom/pexip/sdk/api/infinity/Screen;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/pexip/sdk/api/infinity/RequestedLayout$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/pexip/sdk/api/infinity/RequestedLayout$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/pexip/sdk/api/infinity/RequestedLayout;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/pexip/sdk/api/infinity/RequestedLayout;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/pexip/sdk/api/infinity/RequestedLayout$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
 public final class com/pexip/sdk/api/infinity/RequiredPinException : java/lang/RuntimeException {
 	public fun <init> (Z)V
 	public final fun getGuestPin ()Z
@@ -1359,6 +1418,35 @@ public final class com/pexip/sdk/api/infinity/Role : java/lang/Enum {
 }
 
 public final class com/pexip/sdk/api/infinity/Role$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/pexip/sdk/api/infinity/Screen {
+	public static final field Companion Lcom/pexip/sdk/api/infinity/Screen$Companion;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-09AyAb0 ()Ljava/lang/String;
+	public final fun component2-09AyAb0 ()Ljava/lang/String;
+	public final fun copy-PBtoF5M (Ljava/lang/String;Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/Screen;
+	public static synthetic fun copy-PBtoF5M$default (Lcom/pexip/sdk/api/infinity/Screen;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/Screen;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGuestLayout-09AyAb0 ()Ljava/lang/String;
+	public final fun getHostLayout-09AyAb0 ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/pexip/sdk/api/infinity/Screen$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/pexip/sdk/api/infinity/Screen$$serializer;
+	public fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/pexip/sdk/api/infinity/Screen;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/pexip/sdk/api/infinity/Screen;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/pexip/sdk/api/infinity/Screen$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/Event.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/Event.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,6 +81,16 @@ public data class MessageReceivedEvent(
 ) : Event
 
 @Serializable
+public data class LayoutEvent(
+    @SerialName("view")
+    val layout: LayoutId,
+    @SerialName("requested_layout")
+    val requestedLayout: RequestedLayout,
+    @SerialName("overlay_text_enabled")
+    val overlayTextEnabled: Boolean = false,
+) : Event
+
+@Serializable
 public data class FeccEvent(
     public val action: FeccAction = FeccAction.UNKNOWN,
     public val timeout: Long,
@@ -128,6 +138,7 @@ internal fun Event(json: Json, id: String?, type: String?, data: String): Event?
     "presentation_start" -> json.decodeFromString<PresentationStartEvent>(data)
     "presentation_stop" -> PresentationStopEvent
     "message_received" -> json.decodeFromString<MessageReceivedEvent>(data)
+    "layout" -> json.decodeFromString<LayoutEvent>(data)
     "fecc" -> json.decodeFromString<FeccEvent>(data)
     "refer" -> json.decodeFromString<ReferEvent>(data)
     "splash_screen" -> try {

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -177,7 +177,7 @@ public interface InfinityService {
          * @param token a valid token
          * @return a list of available layouts
          */
-        public fun availableLayouts(token: String): Call<Set<Layout>>
+        public fun availableLayouts(token: String): Call<Set<LayoutId>>
 
         /**
          * This returns a list of all available layouts for the given conference.
@@ -189,7 +189,7 @@ public interface InfinityService {
          * @param token a valid token
          * @return a list of available layouts
          */
-        public fun availableLayouts(token: Token): Call<Set<Layout>>
+        public fun availableLayouts(token: Token): Call<Set<LayoutId>>
 
         /**
          * Provides the theme resources of the conference (direct media only). Used in conjunction

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/LayoutId.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/LayoutId.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Pexip AS
+ * Copyright 2023-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,8 @@
  */
 package com.pexip.sdk.api.infinity
 
-@Deprecated(
-    message = "Renamed to LayoutId",
-    replaceWith = ReplaceWith("LayoutId", "com.pexip.sdk.api.infinity.LayoutId"),
-    level = DeprecationLevel.ERROR,
-)
-public typealias Layout = LayoutId
+import kotlinx.serialization.Serializable
+
+@Serializable
+@JvmInline
+public value class LayoutId(public val value: String)

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/RequestedLayout.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/RequestedLayout.kt
@@ -15,9 +15,11 @@
  */
 package com.pexip.sdk.api.infinity
 
-@Deprecated(
-    message = "Renamed to LayoutId",
-    replaceWith = ReplaceWith("LayoutId", "com.pexip.sdk.api.infinity.LayoutId"),
-    level = DeprecationLevel.ERROR,
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class RequestedLayout(
+    @SerialName("primary_screen")
+    val primaryScreen: Screen,
 )
-public typealias Layout = LayoutId

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/Screen.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/Screen.kt
@@ -15,9 +15,13 @@
  */
 package com.pexip.sdk.api.infinity
 
-@Deprecated(
-    message = "Renamed to LayoutId",
-    replaceWith = ReplaceWith("LayoutId", "com.pexip.sdk.api.infinity.LayoutId"),
-    level = DeprecationLevel.ERROR,
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+public data class Screen(
+    @SerialName("chair_layout")
+    val hostLayout: LayoutId,
+    @SerialName("guest_layout")
+    val guestLayout: LayoutId,
 )
-public typealias Layout = LayoutId

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/AvailableLayoutsSerializer.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/AvailableLayoutsSerializer.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Pexip AS
+ * Copyright 2023-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
  */
 package com.pexip.sdk.api.infinity.internal
 
-import com.pexip.sdk.api.infinity.Layout
+import com.pexip.sdk.api.infinity.LayoutId
 import kotlinx.serialization.builtins.SetSerializer
 
 internal object AvailableLayoutsSerializer :
-    UnboxingSerializer<Set<Layout>>(SetSerializer(Layout.serializer()))
+    UnboxingSerializer<Set<LayoutId>>(SetSerializer(LayoutId.serializer()))

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ import com.pexip.sdk.api.EventSourceFactory
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.InvalidPinException
 import com.pexip.sdk.api.infinity.InvalidTokenException
-import com.pexip.sdk.api.infinity.Layout
+import com.pexip.sdk.api.infinity.LayoutId
 import com.pexip.sdk.api.infinity.MessageRequest
 import com.pexip.sdk.api.infinity.NoSuchConferenceException
 import com.pexip.sdk.api.infinity.NoSuchNodeException
@@ -130,7 +130,7 @@ internal class ConferenceStepImpl(
     override fun message(request: MessageRequest, token: Token): Call<Boolean> =
         message(request, token.token)
 
-    override fun availableLayouts(token: String): Call<Set<Layout>> {
+    override fun availableLayouts(token: String): Call<Set<LayoutId>> {
         require(token.isNotBlank()) { "token is blank." }
         return RealCall(
             client = client,
@@ -146,7 +146,7 @@ internal class ConferenceStepImpl(
         )
     }
 
-    override fun availableLayouts(token: Token): Call<Set<Layout>> = availableLayouts(token.token)
+    override fun availableLayouts(token: Token): Call<Set<LayoutId>> = availableLayouts(token.token)
 
     override fun theme(token: String): Call<Map<String, SplashScreenResponse>> {
         require(token.isNotBlank()) { "token is blank." }

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -473,17 +473,17 @@ internal class ConferenceStepTest {
         }
         val token = Random.nextString(8)
         assertThat(step.availableLayouts(token).await(), "response").containsOnly(
-            Layout("5:7"),
-            Layout("1:7"),
-            Layout("2:21"),
-            Layout("1:21"),
-            Layout("4:0"),
-            Layout("9:0"),
-            Layout("16:0"),
-            Layout("25:0"),
-            Layout("1:0"),
-            Layout("1:33"),
-            Layout("teams"),
+            LayoutId("5:7"),
+            LayoutId("1:7"),
+            LayoutId("2:21"),
+            LayoutId("1:21"),
+            LayoutId("4:0"),
+            LayoutId("9:0"),
+            LayoutId("16:0"),
+            LayoutId("25:0"),
+            LayoutId("1:0"),
+            LayoutId("1:33"),
+            LayoutId("teams"),
         )
         server.verifyAvailableLayouts(token)
     }

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/EventTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/EventTest.kt
@@ -29,6 +29,8 @@ import com.pexip.sdk.api.infinity.FeccMovement
 import com.pexip.sdk.api.infinity.IncomingCancelledEvent
 import com.pexip.sdk.api.infinity.IncomingEvent
 import com.pexip.sdk.api.infinity.InfinityService
+import com.pexip.sdk.api.infinity.LayoutEvent
+import com.pexip.sdk.api.infinity.LayoutId
 import com.pexip.sdk.api.infinity.MessageReceivedEvent
 import com.pexip.sdk.api.infinity.NewCandidateEvent
 import com.pexip.sdk.api.infinity.NewOfferEvent
@@ -42,7 +44,9 @@ import com.pexip.sdk.api.infinity.PeerDisconnectEvent
 import com.pexip.sdk.api.infinity.PresentationStartEvent
 import com.pexip.sdk.api.infinity.PresentationStopEvent
 import com.pexip.sdk.api.infinity.ReferEvent
+import com.pexip.sdk.api.infinity.RequestedLayout
 import com.pexip.sdk.api.infinity.Role
+import com.pexip.sdk.api.infinity.Screen
 import com.pexip.sdk.api.infinity.ServiceType
 import com.pexip.sdk.api.infinity.SplashScreenEvent
 import com.pexip.sdk.api.infinity.UpdateSdpEvent
@@ -278,6 +282,20 @@ internal class EventTest {
                 val2 = "participant_delete.json",
                 val3 = ParticipantDeleteEvent(
                     id = UUID.fromString("0296f038-7f41-4c73-8dcf-0b95bd0138c7"),
+                ),
+            )
+            .row(
+                val1 = "layout",
+                val2 = "layout.json",
+                val3 = LayoutEvent(
+                    layout = LayoutId("1:0"),
+                    requestedLayout = RequestedLayout(
+                        primaryScreen = Screen(
+                            hostLayout = LayoutId("ac"),
+                            guestLayout = LayoutId("ac"),
+                        ),
+                    ),
+                    overlayTextEnabled = true,
                 ),
             )
             .forAll { type, filename, event ->

--- a/sdk-api/src/test/resources/layout.json
+++ b/sdk-api/src/test/resources/layout.json
@@ -1,0 +1,12 @@
+{
+  "view": "1:0",
+  "pres_slot_coords": null,
+  "participants": [],
+  "requested_layout": {
+    "primary_screen": {
+      "chair_layout": "ac",
+      "guest_layout": "ac"
+    }
+  },
+  "overlay_text_enabled": true
+}

--- a/sdk-conference/api/sdk-conference.api
+++ b/sdk-conference/api/sdk-conference.api
@@ -61,6 +61,39 @@ public final class com/pexip/sdk/conference/FailureConferenceEvent : com/pexip/s
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/pexip/sdk/conference/Layout {
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1--VXmZqM ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun component3--VXmZqM ()Ljava/lang/String;
+	public final fun component4--VXmZqM ()Ljava/lang/String;
+	public final fun component5 ()Z
+	public final fun copy-CtZGx_g (Ljava/lang/String;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;Z)Lcom/pexip/sdk/conference/Layout;
+	public static synthetic fun copy-CtZGx_g$default (Lcom/pexip/sdk/conference/Layout;Ljava/lang/String;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/pexip/sdk/conference/Layout;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLayout--VXmZqM ()Ljava/lang/String;
+	public final fun getLayouts ()Ljava/util/Set;
+	public final fun getOverlayTextEnabled ()Z
+	public final fun getRequestedPrimaryScreenGuestLayout--VXmZqM ()Ljava/lang/String;
+	public final fun getRequestedPrimaryScreenHostLayout--VXmZqM ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/pexip/sdk/conference/LayoutId {
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/pexip/sdk/conference/LayoutId;
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
 public final class com/pexip/sdk/conference/Message {
 	public fun <init> (JLjava/util/UUID;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
 	public final fun component1 ()J
@@ -258,6 +291,7 @@ public final class com/pexip/sdk/conference/SplashScreen {
 }
 
 public abstract interface class com/pexip/sdk/conference/Theme {
+	public abstract fun getLayout ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getSplashScreen ()Lkotlinx/coroutines/flow/StateFlow;
 }
 

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Layout.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Layout.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.conference
+
+/**
+ * The layout of this [Conference].
+ *
+ * @property layout a currently visible layout (may be absent from [layouts] in some cases)
+ * @property layouts a set of all available layouts
+ * @property requestedPrimaryScreenHostLayout a requested layout visible on primary screen for hosts
+ * @property requestedPrimaryScreenGuestLayout a requested layout visible on primary screen for guests
+ * @property overlayTextEnabled true if overlay text is enabled, false otherwise
+ */
+public data class Layout(
+    val layout: LayoutId,
+    val layouts: Set<LayoutId>,
+    val requestedPrimaryScreenHostLayout: LayoutId,
+    val requestedPrimaryScreenGuestLayout: LayoutId,
+    val overlayTextEnabled: Boolean,
+)

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/LayoutId.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/LayoutId.kt
@@ -13,11 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.pexip.sdk.api.infinity
+package com.pexip.sdk.conference
 
-@Deprecated(
-    message = "Renamed to LayoutId",
-    replaceWith = ReplaceWith("LayoutId", "com.pexip.sdk.api.infinity.LayoutId"),
-    level = DeprecationLevel.ERROR,
-)
-public typealias Layout = LayoutId
+/**
+ * A unique identifier for a layout in a conference.
+ *
+ * @property value a unique identifier for the layout.
+ */
+@JvmInline
+public value class LayoutId(public val value: String)

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Theme.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Theme.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Pexip AS
+ * Copyright 2023-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,10 +19,16 @@ import kotlinx.coroutines.flow.StateFlow
 
 /**
  * Handles theme-related functionality of the [Conference].
- *
- * @property splashScreen a [StateFlow] of [SplashScreen]s that should be displayed
  */
 public interface Theme {
 
+    /**
+     * A [StateFlow] of current [Layout] state.
+     */
+    public val layout: StateFlow<Layout?>
+
+    /**
+     * A [StateFlow] of [SplashScreen]s that should be displayed.
+     */
     public val splashScreen: StateFlow<SplashScreen?>
 }

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/TestConferenceStep.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/TestConferenceStep.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ package com.pexip.sdk.conference.infinity.internal
 import com.pexip.sdk.api.Call
 import com.pexip.sdk.api.EventSourceFactory
 import com.pexip.sdk.api.infinity.InfinityService
-import com.pexip.sdk.api.infinity.Layout
+import com.pexip.sdk.api.infinity.LayoutId
 import com.pexip.sdk.api.infinity.MessageRequest
 import com.pexip.sdk.api.infinity.RefreshTokenResponse
 import com.pexip.sdk.api.infinity.RequestTokenRequest
@@ -52,9 +52,9 @@ internal abstract class TestConferenceStep : InfinityService.ConferenceStep {
     final override fun message(request: MessageRequest, token: Token): Call<Boolean> =
         message(request, token.token)
 
-    override fun availableLayouts(token: String): Call<Set<Layout>> = TODO()
+    override fun availableLayouts(token: String): Call<Set<LayoutId>> = TODO()
 
-    override fun availableLayouts(token: Token): Call<Set<Layout>> = availableLayouts(token.token)
+    override fun availableLayouts(token: Token): Call<Set<LayoutId>> = availableLayouts(token.token)
 
     override fun theme(token: String): Call<Map<String, SplashScreenResponse>> = TODO()
 


### PR DESCRIPTION
This should provide read-only access to currently active layout of the conference.

Ability to transform the layout will come at a later stage.
