### PR TITLE
fix(conference): certain components missing SSE

### DIFF
--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/DataChannelMessengerImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/DataChannelMessengerImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Pexip AS
+ * Copyright 2023-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,10 +24,12 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.shareIn
 import java.util.UUID
 
 internal class DataChannelMessengerImpl(
@@ -38,7 +40,9 @@ internal class DataChannelMessengerImpl(
     private val atProvider: () -> Long = System::currentTimeMillis,
 ) : AbstractMessenger(scope) {
 
-    override val message: Flow<Message> = dataChannel.data.mapNotNull(::toMessage)
+    override val message: Flow<Message> = dataChannel.data
+        .mapNotNull(::toMessage)
+        .shareIn(scope, SharingStarted.Eagerly)
 
     init {
         message

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,12 +39,16 @@ import com.pexip.sdk.media.RestartSignalingEvent
 import com.pexip.sdk.media.SignalingEvent
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.shareIn
 
 internal class MediaConnectionSignalingImpl(
-    private val store: TokenStore,
+    scope: CoroutineScope,
     event: Flow<Event>,
+    private val store: TokenStore,
     private val participantStep: InfinityService.ParticipantStep,
     override val directMedia: Boolean,
     override val iceServers: List<IceServer>,
@@ -58,7 +62,9 @@ internal class MediaConnectionSignalingImpl(
         else -> CompletableDeferred(callStep)
     }
 
-    override val event: Flow<SignalingEvent> = event.mapNotNull(::toSignalingEvent)
+    override val event: Flow<SignalingEvent> = event
+        .mapNotNull(::toSignalingEvent)
+        .shareIn(scope, SharingStarted.Eagerly)
 
     override suspend fun onOffer(
         callType: String,

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/MessengerImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/MessengerImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Pexip AS
+ * Copyright 2023-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,11 +27,13 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.shareIn
 import java.util.UUID
 
 internal class MessengerImpl(
@@ -56,6 +58,7 @@ internal class MessengerImpl(
                 direct = it.direct,
             )
         }
+        .shareIn(scope, SharingStarted.Eagerly)
 
     init {
         message

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/Util.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/Util.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.conference.infinity.internal
+
+import kotlinx.coroutines.flow.SharingCommand
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+
+@Suppress("ktlint:standard:function-naming")
+internal fun SharingStarted.Companion.WhileSubscribedAtLeast(threshold: Int) =
+    SharingStarted { subscriptionCount ->
+        subscriptionCount
+            .map { if (it >= threshold) SharingCommand.START else SharingCommand.STOP_AND_RESET_REPLAY_CACHE }
+            .distinctUntilChanged()
+    }

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -76,14 +76,15 @@ internal class MediaConnectionSignalingImplTest {
     }
 
     @Test
-    fun `directMedia returns correct value`() {
+    fun `directMedia returns correct value`() = runTest {
         tableOf("directMedia")
             .row(false)
             .row(true)
             .forAll {
                 val signaling = MediaConnectionSignalingImpl(
-                    store = store,
+                    scope = backgroundScope,
                     event = event,
+                    store = store,
                     participantStep = object : TestParticipantStep() {},
                     directMedia = it,
                     iceServers = iceServers,
@@ -95,10 +96,11 @@ internal class MediaConnectionSignalingImplTest {
     }
 
     @Test
-    fun `iceServers return IceServer list`() {
+    fun `iceServers return IceServer list`() = runTest {
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {},
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
@@ -109,14 +111,15 @@ internal class MediaConnectionSignalingImplTest {
     }
 
     @Test
-    fun `iceTransportsRelayOnly returns correct value`() {
+    fun `iceTransportsRelayOnly returns correct value`() = runTest {
         tableOf("iceTransportsRelayOnly")
             .row(false)
             .row(true)
             .forAll {
                 val signaling = MediaConnectionSignalingImpl(
-                    store = store,
+                    scope = backgroundScope,
                     event = event,
+                    store = store,
                     participantStep = object : TestParticipantStep() {},
                     directMedia = Random.nextBoolean(),
                     iceServers = iceServers,
@@ -128,11 +131,12 @@ internal class MediaConnectionSignalingImplTest {
     }
 
     @Test
-    fun `dataChannel returns the correct value`() {
+    fun `dataChannel returns the correct value`() = runTest {
         val dataChannel = DataChannelImpl(Random.nextInt())
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {},
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
@@ -146,8 +150,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `NewOfferEvent is mapped to OfferSignalingEvent`() = runTest {
         val participantStep = object : TestParticipantStep() {}
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = participantStep,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
@@ -155,6 +160,7 @@ internal class MediaConnectionSignalingImplTest {
             dataChannel = null,
         )
         signaling.event.test {
+            event.awaitSubscriptionCountAtLeast(1)
             repeat(10) {
                 val e = NewOfferEvent(Random.nextString(8))
                 event.emit(e)
@@ -170,8 +176,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `UpdateSdpEvent is mapped to OfferSignalingEvent`() = runTest {
         val participantStep = object : TestParticipantStep() {}
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = participantStep,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
@@ -179,6 +186,7 @@ internal class MediaConnectionSignalingImplTest {
             dataChannel = null,
         )
         signaling.event.test {
+            event.awaitSubscriptionCountAtLeast(1)
             repeat(10) {
                 val e = UpdateSdpEvent(Random.nextString(8))
                 event.emit(e)
@@ -194,8 +202,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `NewCandidateEvent is mapped to CandidateSignalingEvent`() = runTest {
         val participantStep = object : TestParticipantStep() {}
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = participantStep,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
@@ -203,6 +212,7 @@ internal class MediaConnectionSignalingImplTest {
             dataChannel = null,
         )
         signaling.event.test {
+            event.awaitSubscriptionCountAtLeast(1)
             repeat(10) {
                 val e = NewCandidateEvent(
                     candidate = Random.nextString(8),
@@ -225,8 +235,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `PeerDisconnectedEvent is mapped to RestartSignalingEvent`() = runTest {
         val participantStep = object : TestParticipantStep() {}
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = participantStep,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
@@ -234,6 +245,7 @@ internal class MediaConnectionSignalingImplTest {
             dataChannel = null,
         )
         signaling.event.test {
+            event.awaitSubscriptionCountAtLeast(1)
             repeat(10) {
                 event.emit(PeerDisconnectEvent)
                 assertThat(awaitItem(), "event").isInstanceOf<RestartSignalingEvent>()
@@ -245,8 +257,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `ignores unknown Events`() = runTest {
         val participantStep = object : TestParticipantStep() {}
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = participantStep,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
@@ -254,6 +267,7 @@ internal class MediaConnectionSignalingImplTest {
             dataChannel = null,
         )
         signaling.event.test {
+            event.awaitSubscriptionCountAtLeast(1)
             repeat(10) { event.emit(object : Event {}) }
             expectNoEvents()
         }
@@ -302,8 +316,9 @@ internal class MediaConnectionSignalingImplTest {
                 }
             }
             val signaling = MediaConnectionSignalingImpl(
-                store = store,
+                scope = backgroundScope,
                 event = event,
+                store = store,
                 participantStep = participantStep,
                 directMedia = Random.nextBoolean(),
                 iceServers = iceServers,
@@ -340,8 +355,9 @@ internal class MediaConnectionSignalingImplTest {
         )
         responses.forEach { response ->
             val signaling = MediaConnectionSignalingImpl(
-                store = store,
+                scope = backgroundScope,
                 event = event,
+                store = store,
                 participantStep = object : TestParticipantStep() {},
                 directMedia = Random.nextBoolean(),
                 iceServers = iceServers,
@@ -379,8 +395,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `onOfferIgnored() returns`() = runTest {
         val called = Job()
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {},
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
@@ -408,8 +425,9 @@ internal class MediaConnectionSignalingImplTest {
         val called = Job()
         val sdp = Random.nextString(8)
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {},
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
@@ -436,8 +454,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `onAck() returns`() = runTest {
         val called = Job()
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {},
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
@@ -464,8 +483,9 @@ internal class MediaConnectionSignalingImplTest {
         val ufrag = Random.nextString(8)
         val pwd = Random.nextString(8)
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {},
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
@@ -496,8 +516,9 @@ internal class MediaConnectionSignalingImplTest {
         val digits = Random.nextDigits(8)
         val result = Random.nextBoolean()
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {},
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
@@ -522,8 +543,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `onAudioMuted() returns`() = runTest {
         val called = Job()
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {
                 override fun mute(token: String): Call<Unit> = object : TestCall<Unit> {
                     override fun enqueue(callback: Callback<Unit>) {
@@ -546,8 +568,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `onAudioUnmuted() returns`() = runTest {
         val called = Job()
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {
                 override fun unmute(token: String): Call<Unit> = object : TestCall<Unit> {
                     override fun enqueue(callback: Callback<Unit>) {
@@ -570,8 +593,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `onVideoMuted() returns`() = runTest {
         val called = Job()
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {
                 override fun videoMuted(token: String): Call<Unit> = object : TestCall<Unit> {
                     override fun enqueue(callback: Callback<Unit>) {
@@ -594,8 +618,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `onVideoUnmuted() returns`() = runTest {
         val called = Job()
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {
                 override fun videoUnmuted(token: String): Call<Unit> = object : TestCall<Unit> {
                     override fun enqueue(callback: Callback<Unit>) {
@@ -618,8 +643,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `onTakeFloor() returns`() = runTest {
         val called = Job()
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {
                 override fun takeFloor(token: String): Call<Unit> = object : TestCall<Unit> {
                     override fun enqueue(callback: Callback<Unit>) {
@@ -642,8 +668,9 @@ internal class MediaConnectionSignalingImplTest {
     fun `onReleaseFloor() returns`() = runTest {
         val called = Job()
         val signaling = MediaConnectionSignalingImpl(
-            store = store,
+            scope = backgroundScope,
             event = event,
+            store = store,
             participantStep = object : TestParticipantStep() {
                 override fun releaseFloor(token: String): Call<Unit> = object : TestCall<Unit> {
                     override fun enqueue(callback: Callback<Unit>) {

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/MessengerImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/MessengerImplTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Pexip AS
+ * Copyright 2023-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import com.pexip.sdk.api.infinity.MessageRequest
 import com.pexip.sdk.api.infinity.TokenStore
 import com.pexip.sdk.conference.MessageNotSentException
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import java.util.UUID
 import kotlin.random.Random
@@ -269,6 +270,7 @@ class MessengerImplTest {
             atProvider = { at },
         )
         messenger.message.test {
+            event.subscriptionCount.first { it > 0 }
             val messages = List(10) { Random.nextMessage(at = at, direct = it % 2 == 0) }
             messages.forEach {
                 val e = MessageReceivedEvent(

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImplTest.kt
@@ -40,7 +40,6 @@ import com.pexip.sdk.conference.Layout
 import com.pexip.sdk.conference.LayoutId
 import com.pexip.sdk.conference.SplashScreen
 import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.random.Random
 import kotlin.test.BeforeTest
@@ -96,7 +95,7 @@ class ThemeImplTest {
             store = store,
         )
         theme.layout.test {
-            event.subscriptionCount.first { it > 0 }
+            event.awaitSubscriptionCountAtLeast(2)
             assertThat(awaitItem(), "layout").isNull()
             repeat(10) {
                 val e = LayoutEvent(
@@ -172,7 +171,7 @@ class ThemeImplTest {
             store = store,
         )
         theme.splashScreen.test {
-            event.subscriptionCount.first { it > 0 }
+            event.awaitSubscriptionCountAtLeast(2)
             assertThat(awaitItem()).isNull()
             event.emit(SplashScreenEvent(Random.nextString(8)))
             expectNoEvents()

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/Util.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/Util.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,8 @@ package com.pexip.sdk.conference.infinity.internal
 import com.pexip.sdk.api.infinity.DtmfRequest
 import com.pexip.sdk.api.infinity.RefreshTokenResponse
 import com.pexip.sdk.conference.Message
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
 import java.util.UUID
 import kotlin.random.Random
 
@@ -43,3 +45,8 @@ internal fun Random.nextMessage(at: Long = System.currentTimeMillis(), direct: B
         payload = nextString(64),
         direct = direct,
     )
+
+internal suspend fun <T> MutableSharedFlow<T>.awaitSubscriptionCountAtLeast(threshold: Int): Int {
+    require(threshold > 0) { "threshold must be a positive number." }
+    return subscriptionCount.first { it >= threshold }
+}


### PR DESCRIPTION
This was most obvious with the recent addition of `Layout`. The SSE would arrive before the `Theme.layout` had a chance to subscribe and the current "state" would end up being ignored.

This PR forces the underlying `event` to wait until all expected subscribers are active to initiate the connection.

An alternative implementation that relied on debouncing was considered, but was dismissed due to being unreliable (hard to guess the correct timeout value).