### PR TITLE
feat(conference): add a way to transform layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - `Theme.layout` that provides the currently active layout of the conference
+- `Theme.transformLayout` to modify the layout of the conference
 - `UnsupportedInfinityException` to indicate when the deployment is not supported by the SDK
 
 ### Changed

--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -465,6 +465,12 @@ public final class com/pexip/sdk/api/infinity/IdentityProviderId$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/pexip/sdk/api/infinity/IllegalLayoutTransformException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class com/pexip/sdk/api/infinity/IncomingCancelledEvent : com/pexip/sdk/api/Event {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/IncomingCancelledEvent$Companion;
 	public fun <init> (Ljava/lang/String;)V
@@ -1593,7 +1599,7 @@ public final class com/pexip/sdk/api/infinity/TransformLayoutRequest {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getEnableOverlayText ()Ljava/lang/Boolean;
 	public final fun getGuestLayout-8Fcadpo ()Ljava/lang/String;
-	public final fun getHostLayout-8Fcadpo ()Ljava/lang/String;
+	public final fun getLayout-8Fcadpo ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/IllegalLayoutTransformException.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/IllegalLayoutTransformException.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.pexip.sdk.infinity
+package com.pexip.sdk.api.infinity
 
 /**
  * Thrown to indicate that the requested layout transformation is unsupported.

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
@@ -17,6 +17,7 @@ package com.pexip.sdk.api.infinity.internal
 
 import com.pexip.sdk.api.Call
 import com.pexip.sdk.api.EventSourceFactory
+import com.pexip.sdk.api.infinity.IllegalLayoutTransformException
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.InvalidPinException
 import com.pexip.sdk.api.infinity.InvalidTokenException
@@ -33,7 +34,6 @@ import com.pexip.sdk.api.infinity.SplashScreenResponse
 import com.pexip.sdk.api.infinity.SsoRedirectException
 import com.pexip.sdk.api.infinity.Token
 import com.pexip.sdk.api.infinity.TransformLayoutRequest
-import com.pexip.sdk.infinity.IllegalLayoutTransformException
 import kotlinx.serialization.SerializationException
 import okhttp3.Request
 import okhttp3.Response

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
@@ -30,7 +30,6 @@ import com.pexip.sdk.api.infinity.internal.RequiredPinResponse
 import com.pexip.sdk.api.infinity.internal.RequiredSsoResponse
 import com.pexip.sdk.api.infinity.internal.SsoRedirectResponse
 import com.pexip.sdk.api.infinity.internal.TransformLayoutRequestSerializer
-import com.pexip.sdk.infinity.IllegalLayoutTransformException
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -557,7 +556,7 @@ internal class ConferenceStepTest {
     fun `transformLayout throws IllegalStateException`() = runTest {
         server.enqueue { setResponseCode(500) }
         val request = TransformLayoutRequest(
-            hostLayout = LayoutId(Random.nextString(8)),
+            layout = LayoutId(Random.nextString(8)),
             guestLayout = LayoutId(Random.nextString(8)),
             enableOverlayText = Random.nextBoolean(),
         )
@@ -575,7 +574,7 @@ internal class ConferenceStepTest {
             setBody(body)
         }
         val request = TransformLayoutRequest(
-            hostLayout = LayoutId(Random.nextString(8)),
+            layout = LayoutId(Random.nextString(8)),
             guestLayout = LayoutId(Random.nextString(8)),
             enableOverlayText = Random.nextBoolean(),
         )
@@ -589,7 +588,7 @@ internal class ConferenceStepTest {
     fun `transformLayout throws NoSuchNodeException`() = runTest {
         server.enqueue { setResponseCode(404) }
         val request = TransformLayoutRequest(
-            hostLayout = LayoutId(Random.nextString(8)),
+            layout = LayoutId(Random.nextString(8)),
             guestLayout = LayoutId(Random.nextString(8)),
             enableOverlayText = Random.nextBoolean(),
         )
@@ -607,7 +606,7 @@ internal class ConferenceStepTest {
             setBody(body)
         }
         val request = TransformLayoutRequest(
-            hostLayout = LayoutId(Random.nextString(8)),
+            layout = LayoutId(Random.nextString(8)),
             guestLayout = LayoutId(Random.nextString(8)),
             enableOverlayText = Random.nextBoolean(),
         )
@@ -625,7 +624,7 @@ internal class ConferenceStepTest {
             setBody(body)
         }
         val request = TransformLayoutRequest(
-            hostLayout = LayoutId(Random.nextString(8)),
+            layout = LayoutId(Random.nextString(8)),
             guestLayout = LayoutId(Random.nextString(8)),
             enableOverlayText = Random.nextBoolean(),
         )
@@ -644,7 +643,7 @@ internal class ConferenceStepTest {
                 setBody(json.encodeToString(Box(result)))
             }
             val request = TransformLayoutRequest(
-                hostLayout = LayoutId(Random.nextString(8)),
+                layout = LayoutId(Random.nextString(8)),
                 guestLayout = LayoutId(Random.nextString(8)),
                 enableOverlayText = Random.nextBoolean(),
             )

--- a/sdk-conference/api/sdk-conference.api
+++ b/sdk-conference/api/sdk-conference.api
@@ -295,6 +295,14 @@ public final class com/pexip/sdk/conference/SplashScreen {
 public abstract interface class com/pexip/sdk/conference/Theme {
 	public abstract fun getLayout ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getSplashScreen ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun transformLayout-ea01N14 (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun transformLayout-ea01N14$default (Lcom/pexip/sdk/conference/Theme;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+}
+
+public final class com/pexip/sdk/conference/TransformLayoutException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class com/pexip/sdk/conference/coroutines/UtilKt {

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Theme.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Theme.kt
@@ -31,4 +31,23 @@ public interface Theme {
      * A [StateFlow] of [SplashScreen]s that should be displayed.
      */
     public val splashScreen: StateFlow<SplashScreen?>
+
+    /**
+     * Transforms the current conference layout given sufficient privileges.
+     *
+     * Calling this method with the default parameters resets any prior transformations applied
+     * to the conference layout.
+     *
+     * Changes are applied cumulatively.
+     *
+     * @param layout a layout visible to hosts and guests
+     * @param guestLayout a layout visible to guests in Virtual Auditoriums
+     * @param enableOverlayText true if per-participant overlay text is enabled, false otherwise
+     * @throws TransformLayoutException if layout transformation was not applied
+     */
+    public suspend fun transformLayout(
+        layout: LayoutId? = null,
+        guestLayout: LayoutId? = null,
+        enableOverlayText: Boolean? = null,
+    )
 }

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/TransformLayoutException.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/TransformLayoutException.kt
@@ -13,17 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.pexip.sdk.api.infinity
+package com.pexip.sdk.conference
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
-public data class TransformLayoutRequest(
-    @SerialName("layout")
-    val layout: LayoutId? = null,
-    @SerialName("guest_layout")
-    val guestLayout: LayoutId? = null,
-    @SerialName("enable_overlay_text")
-    val enableOverlayText: Boolean? = null,
-)
+/**
+ * Thrown to indicate that layout transformation has failed.
+ *
+ * @property cause a cause of this exception
+ */
+public class TransformLayoutException @JvmOverloads constructor(cause: Throwable? = null) :
+    RuntimeException("Failed to transform the layout.", cause)

--- a/sdk-infinity/api/sdk-infinity.api
+++ b/sdk-infinity/api/sdk-infinity.api
@@ -1,9 +1,3 @@
-public final class com/pexip/sdk/infinity/IllegalLayoutTransformException : java/lang/RuntimeException {
-	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-}
-
 public final class com/pexip/sdk/infinity/UnsupportedInfinityException : java/lang/IllegalArgumentException {
 	public fun <init> (Ljava/lang/String;)V
 	public final fun getVersion ()Ljava/lang/String;


### PR DESCRIPTION
This also renames `host_layout` to `layout` (since they are aliases) to better indicate that `host_layout`/`layout` alter the layout for guests in non-Virtual Auditorium calls.