### PR TITLE
fix(conference)!: make Participant.startTime nullable

### DIFF
--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/ParticipantResponse.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/ParticipantResponse.kt
@@ -30,7 +30,7 @@ public data class ParticipantResponse(
     @SerialName("uuid")
     val id: UUID,
     @SerialName("start_time")
-    val startTime: Instant,
+    val startTime: Instant? = null,
     @SerialName("display_name")
     val displayName: String,
     @SerialName("overlay_text")

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/ParticipantResponse.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/ParticipantResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Pexip AS
+ * Copyright 2023-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ParticipantResponseSerializer.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ParticipantResponseSerializer.kt
@@ -52,7 +52,7 @@ internal object ParticipantResponseSerializer :
 
     private fun JsonElement.toInstantComponents(): JsonElement {
         val content = jsonPrimitive.content
-        if (content == "0") return JsonNull
+        if (content == "0" || content == "null") return JsonNull
         val parts = content.split(".", limit = 2)
         return buildJsonObject {
             val epochSeconds = parts[0]

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Participant.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Participant.kt
@@ -25,7 +25,7 @@ import java.util.UUID
  * @property role a role of this participant
  * @property serviceType a service type of this participant
  * @property startTime a UNIX timestamp representing the moment in time when this participant
- * joined the conference
+ * joined the conference, or null
  * @property buzzTime a UNIX timestamp representing the moment in time when this participant
  * raised their hand, or null if their hand is not currently raised
  * @property spotlightTime a UNIX timestamp representing the moment in time when this participant
@@ -43,7 +43,7 @@ public data class Participant(
     val id: UUID,
     val role: Role,
     val serviceType: ServiceType,
-    val startTime: Instant,
+    val startTime: Instant?,
     val buzzTime: Instant?,
     val spotlightTime: Instant?,
     val displayName: String,

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Participant.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Participant.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Pexip AS
+ * Copyright 2023-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
There are some cases when it can be `null` in the payload, namely when dialing a user on Pexip Service. This may potentially be true other dialing scenarios.