### PR TITLE
feat(conference): add Roster.me

### DIFF
--- a/sdk-conference/api/sdk-conference.api
+++ b/sdk-conference/api/sdk-conference.api
@@ -273,6 +273,7 @@ public final class com/pexip/sdk/conference/Role : java/lang/Enum {
 }
 
 public abstract interface class com/pexip/sdk/conference/Roster {
+	public abstract fun getMe ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getParticipants ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun lowerAllHands (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun lowerHand (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Roster.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Roster.kt
@@ -29,6 +29,11 @@ public interface Roster {
     public val participants: StateFlow<List<Participant>>
 
     /**
+     * A [StateFlow] that represents *you* as the participant of this conference.
+     */
+    public val me: StateFlow<Participant?>
+
+    /**
      * Raises hand of the specified participant or self.
      *
      * @param participantId an ID of the participant, null for self


### PR DESCRIPTION
This points to *your* participant object in the conference and will be useful for getting things like current "hand" state (whether raised or not), etc.