### PR TITLE
feat(conference): add Roster.presenter

### DIFF
--- a/sdk-conference/api/sdk-conference.api
+++ b/sdk-conference/api/sdk-conference.api
@@ -275,6 +275,7 @@ public final class com/pexip/sdk/conference/Role : java/lang/Enum {
 public abstract interface class com/pexip/sdk/conference/Roster {
 	public abstract fun getMe ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getParticipants ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPresenter ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun lowerAllHands (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun lowerHand (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun lowerHand$default (Lcom/pexip/sdk/conference/Roster;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Roster.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Roster.kt
@@ -34,6 +34,13 @@ public interface Roster {
     public val me: StateFlow<Participant?>
 
     /**
+     * A [StateFlow] that represents the participant that is currently sharing a presentation.
+     *
+     * Note that the value will always be `null` when you're sharing the presentation.
+     */
+    public val presenter: StateFlow<Participant?>
+
+    /**
      * Raises hand of the specified participant or self.
      *
      * @param participantId an ID of the participant, null for self

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
@@ -69,7 +69,7 @@ public class InfinityConference private constructor(
 
     // To ensure that all subscribers see SSE we wait until all known subscribers are active.
     // This has to be updated every time we add another subscriber to the event.
-    private val threshold = if (response.dataChannelId == -1) 5 else 6
+    private val threshold = if (response.dataChannelId == -1) 6 else 7
     private val event =
         step.events(store).shareIn(scope, SharingStarted.WhileSubscribedAtLeast(threshold))
     private val listeners = CopyOnWriteArraySet<ConferenceEventListener>()


### PR DESCRIPTION
This property can be used as a more reliable replacement for `PresentationStartConferenceEvent` and `PresentationStopConferenceEvent`.