### PR TITLE
fix(conference): use debounce for event subscription

### DIFF
--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImpl.kt
@@ -44,7 +44,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.stateIn
 import kotlin.time.Duration.Companion.seconds

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImpl.kt
@@ -58,7 +58,7 @@ internal class ThemeImpl(
 ) : Theme {
 
     override val layout: StateFlow<Layout?> = combine(
-        flow = event.filterIsInstance<LayoutEvent>().onEach(::println),
+        flow = event.filterIsInstance<LayoutEvent>(),
         flow2 = step.availableLayouts(store),
         flow3 = step.layoutSvgs(store),
         transform = ::toLayout,

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImpl.kt
@@ -44,6 +44,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.stateIn
 import kotlin.time.Duration.Companion.seconds
@@ -57,7 +58,7 @@ internal class ThemeImpl(
 ) : Theme {
 
     override val layout: StateFlow<Layout?> = combine(
-        flow = event.filterIsInstance<LayoutEvent>(),
+        flow = event.filterIsInstance<LayoutEvent>().onEach(::println),
         flow2 = step.availableLayouts(store),
         flow3 = step.layoutSvgs(store),
         transform = ::toLayout,

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/Util.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/Util.kt
@@ -15,15 +15,21 @@
  */
 package com.pexip.sdk.conference.infinity.internal
 
+import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.SharingCommand
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlin.time.Duration
 
+@OptIn(FlowPreview::class)
 @Suppress("ktlint:standard:function-naming")
-internal fun SharingStarted.Companion.WhileSubscribedAtLeast(threshold: Int) =
+internal fun SharingStarted.Companion.WhileSubscribedWithDebounce(timeout: Duration) =
     SharingStarted { subscriptionCount ->
         subscriptionCount
-            .map { if (it >= threshold) SharingCommand.START else SharingCommand.STOP_AND_RESET_REPLAY_CACHE }
+            .map { it > 0 }
             .distinctUntilChanged()
+            .debounce(timeout)
+            .map { if (it) SharingCommand.START else SharingCommand.STOP_AND_RESET_REPLAY_CACHE }
     }


### PR DESCRIPTION
Prior approach still had some issues with `layout` event and API participants.