### PR TITLE
fix(api)!: make RequestedLayout nullable

### DIFF
--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/Event.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/Event.kt
@@ -85,7 +85,7 @@ public data class LayoutEvent(
     @SerialName("view")
     val layout: LayoutId,
     @SerialName("requested_layout")
-    val requestedLayout: RequestedLayout,
+    val requestedLayout: RequestedLayout? = null,
     @SerialName("overlay_text_enabled")
     val overlayTextEnabled: Boolean = false,
 ) : Event

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/EventTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/EventTest.kt
@@ -298,6 +298,11 @@ internal class EventTest {
                     overlayTextEnabled = true,
                 ),
             )
+            .row(
+                val1 = "layout",
+                val2 = "layout_direct_media.json",
+                val3 = LayoutEvent(layout = LayoutId("1:0")),
+            )
             .forAll { type, filename, event ->
                 val data = FileSystem.RESOURCES.readUtf8(filename)
                 val actual = Event(

--- a/sdk-api/src/test/resources/layout_direct_media.json
+++ b/sdk-api/src/test/resources/layout_direct_media.json
@@ -1,0 +1,4 @@
+{
+  "participants": "c7a08522-5bd5-4d39-a2ce-a8d97bb9c80d",
+  "view": "1:0"
+}

--- a/sdk-conference/api/sdk-conference.api
+++ b/sdk-conference/api/sdk-conference.api
@@ -71,19 +71,19 @@ public final class com/pexip/sdk/conference/Layout {
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Map;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1--VXmZqM ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/Set;
-	public final fun component3--VXmZqM ()Ljava/lang/String;
-	public final fun component4--VXmZqM ()Ljava/lang/String;
+	public final fun component3-9iqCO30 ()Ljava/lang/String;
+	public final fun component4-9iqCO30 ()Ljava/lang/String;
 	public final fun component5 ()Z
 	public final fun component6 ()Ljava/util/Map;
-	public final fun copy--vECkHw (Ljava/lang/String;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Map;)Lcom/pexip/sdk/conference/Layout;
-	public static synthetic fun copy--vECkHw$default (Lcom/pexip/sdk/conference/Layout;Ljava/lang/String;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Map;ILjava/lang/Object;)Lcom/pexip/sdk/conference/Layout;
+	public final fun copy-vlG9LLU (Ljava/lang/String;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Map;)Lcom/pexip/sdk/conference/Layout;
+	public static synthetic fun copy-vlG9LLU$default (Lcom/pexip/sdk/conference/Layout;Ljava/lang/String;Ljava/util/Set;Ljava/lang/String;Ljava/lang/String;ZLjava/util/Map;ILjava/lang/Object;)Lcom/pexip/sdk/conference/Layout;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getLayout--VXmZqM ()Ljava/lang/String;
 	public final fun getLayoutSvgs ()Ljava/util/Map;
 	public final fun getLayouts ()Ljava/util/Set;
 	public final fun getOverlayTextEnabled ()Z
-	public final fun getRequestedPrimaryScreenGuestLayout--VXmZqM ()Ljava/lang/String;
-	public final fun getRequestedPrimaryScreenHostLayout--VXmZqM ()Ljava/lang/String;
+	public final fun getRequestedPrimaryScreenGuestLayout-9iqCO30 ()Ljava/lang/String;
+	public final fun getRequestedPrimaryScreenHostLayout-9iqCO30 ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Layout.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Layout.kt
@@ -20,15 +20,15 @@ package com.pexip.sdk.conference
  *
  * @property layout a currently visible layout (may be absent from [layouts] in some cases)
  * @property layouts a set of all available layouts
- * @property requestedPrimaryScreenHostLayout a requested layout visible on primary screen for hosts
- * @property requestedPrimaryScreenGuestLayout a requested layout visible on primary screen for guests
+ * @property requestedPrimaryScreenHostLayout a requested layout visible on primary screen for hosts, may be null in direct media call
+ * @property requestedPrimaryScreenGuestLayout a requested layout visible on primary screen for guests, may be null in direct media call
  * @property overlayTextEnabled true if overlay text is enabled, false otherwise
  */
 public data class Layout(
     val layout: LayoutId,
     val layouts: Set<LayoutId>,
-    val requestedPrimaryScreenHostLayout: LayoutId,
-    val requestedPrimaryScreenGuestLayout: LayoutId,
+    val requestedPrimaryScreenHostLayout: LayoutId?,
+    val requestedPrimaryScreenGuestLayout: LayoutId?,
     val overlayTextEnabled: Boolean,
     val layoutSvgs: Map<LayoutId, String>,
 )

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImpl.kt
@@ -45,6 +45,7 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
@@ -110,7 +111,9 @@ internal class RosterImpl(
         .stateIn(scope, SharingStarted.Eagerly, null)
 
     override val presenter: StateFlow<Participant?> = combine(
-        flow = event.filter { it is PresentationStartEvent || it is PresentationStopEvent },
+        flow = event
+            .onEach(::println)
+            .filter { it is PresentationStartEvent || it is PresentationStopEvent },
         flow2 = participantMapFlow,
         transform = { event, map ->
             when (event) {

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImpl.kt
@@ -94,8 +94,14 @@ internal class ThemeImpl(
     ) = Layout(
         layout = LayoutId(event.layout),
         layouts = layoutIds.asSequence().map(::LayoutId).toSet(),
-        requestedPrimaryScreenHostLayout = LayoutId(event.requestedLayout.primaryScreen.hostLayout),
-        requestedPrimaryScreenGuestLayout = LayoutId(event.requestedLayout.primaryScreen.guestLayout),
+        requestedPrimaryScreenHostLayout = event.requestedLayout
+            ?.primaryScreen
+            ?.hostLayout
+            ?.let(::LayoutId),
+        requestedPrimaryScreenGuestLayout = event.requestedLayout
+            ?.primaryScreen
+            ?.guestLayout
+            ?.let(::LayoutId),
         overlayTextEnabled = event.overlayTextEnabled,
         layoutSvgs = layoutSvgs.mapKeys { LayoutId(it.key) },
     )

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImplTest.kt
@@ -140,9 +140,11 @@ class ThemeImplTest {
                             .extracting(LayoutId::value)
                             .containsExactly(*layouts.map(ApiLayoutId::value).toTypedArray())
                         prop(Layout::requestedPrimaryScreenHostLayout)
-                            .isEqualTo(e.requestedLayout.primaryScreen.hostLayout)
+                            .isNotNull()
+                            .isEqualTo(e.requestedLayout?.primaryScreen?.hostLayout)
                         prop(Layout::requestedPrimaryScreenGuestLayout)
-                            .isEqualTo(e.requestedLayout.primaryScreen.guestLayout)
+                            .isNotNull()
+                            .isEqualTo(e.requestedLayout?.primaryScreen?.guestLayout)
                         prop(Layout::overlayTextEnabled).isEqualTo(e.overlayTextEnabled)
                         prop(Layout::layoutSvgs).all {
                             layoutSvgs.forEach { key(LayoutId(it.key.value)).isEqualTo(it.value) }
@@ -288,8 +290,8 @@ class ThemeImplTest {
         }
     }
 
-    private fun Assert<LayoutId>.isEqualTo(id: ApiLayoutId) =
-        prop(LayoutId::value).isEqualTo(id.value)
+    private fun Assert<LayoutId>.isEqualTo(id: ApiLayoutId?) =
+        prop(LayoutId::value).isEqualTo(id?.value)
 
     private fun Random.nextLayoutId() = LayoutId(nextString(8))
 }


### PR DESCRIPTION
It's not present in direct media `layout` event and causes some issues in direct media calls.