### PR TITLE
feat(conference): add mute and unmute to Roster

### DIFF
--- a/sdk-conference/api/sdk-conference.api
+++ b/sdk-conference/api/sdk-conference.api
@@ -175,6 +175,12 @@ public abstract interface class com/pexip/sdk/conference/Messenger {
 	public abstract fun unregisterMessageListener (Lcom/pexip/sdk/conference/MessageListener;)V
 }
 
+public final class com/pexip/sdk/conference/MuteException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class com/pexip/sdk/conference/Participant {
 	public fun <init> (Ljava/util/UUID;Lcom/pexip/sdk/conference/Role;Lcom/pexip/sdk/conference/ServiceType;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/String;ZZZZZZ)V
 	public final fun component1 ()Ljava/util/UUID;
@@ -279,16 +285,26 @@ public final class com/pexip/sdk/conference/Role : java/lang/Enum {
 }
 
 public abstract interface class com/pexip/sdk/conference/Roster {
-	public abstract fun disconnect (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun disconnect (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun disconnect$default (Lcom/pexip/sdk/conference/Roster;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun getMe ()Lkotlinx/coroutines/flow/StateFlow;
-	public abstract fun getParticipants ()Lkotlinx/coroutines/flow/StateFlow;
-	public abstract fun getPresenter ()Lkotlinx/coroutines/flow/StateFlow;
-	public abstract fun lowerAllHands (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun lowerHand (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun disconnect$suspendImpl (Lcom/pexip/sdk/conference/Roster;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun getMe ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getParticipants ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getPresenter ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun lowerAllHands (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun lowerAllHands$suspendImpl (Lcom/pexip/sdk/conference/Roster;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun lowerHand (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun lowerHand$default (Lcom/pexip/sdk/conference/Roster;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public abstract fun raiseHand (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun lowerHand$suspendImpl (Lcom/pexip/sdk/conference/Roster;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun mute (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun mute$default (Lcom/pexip/sdk/conference/Roster;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun mute$suspendImpl (Lcom/pexip/sdk/conference/Roster;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun raiseHand (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun raiseHand$default (Lcom/pexip/sdk/conference/Roster;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun raiseHand$suspendImpl (Lcom/pexip/sdk/conference/Roster;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun unmute (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun unmute$default (Lcom/pexip/sdk/conference/Roster;Ljava/util/UUID;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static synthetic fun unmute$suspendImpl (Lcom/pexip/sdk/conference/Roster;Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class com/pexip/sdk/conference/SendCallback {
@@ -333,6 +349,12 @@ public abstract interface class com/pexip/sdk/conference/Theme {
 }
 
 public final class com/pexip/sdk/conference/TransformLayoutException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/pexip/sdk/conference/UnmuteException : java/lang/RuntimeException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Throwable;)V
 	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/MuteException.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/MuteException.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.conference
+
+/**
+ * Thrown to indicate that mute failed.
+ *
+ * @property cause a cause of this exception
+ */
+public class MuteException @JvmOverloads constructor(cause: Throwable? = null) :
+    RuntimeException("Failed to mute.", cause)

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Roster.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Roster.kt
@@ -27,11 +27,13 @@ public interface Roster {
      * A [StateFlow] that represents participants of this conference.
      */
     public val participants: StateFlow<List<Participant>>
+        get() = throw NotImplementedError()
 
     /**
      * A [StateFlow] that represents *you* as the participant of this conference.
      */
     public val me: StateFlow<Participant?>
+        get() = throw NotImplementedError()
 
     /**
      * A [StateFlow] that represents the participant that is currently sharing a presentation.
@@ -39,6 +41,7 @@ public interface Roster {
      * Note that the value will always be `null` when you're sharing the presentation.
      */
     public val presenter: StateFlow<Participant?>
+        get() = throw NotImplementedError()
 
     /**
      * Disconnects the specified participant or self.
@@ -46,7 +49,23 @@ public interface Roster {
      * @param participantId an ID of the participant, null for self
      * @throws DisconnectException if the operation failed
      */
-    public suspend fun disconnect(participantId: UUID? = null)
+    public suspend fun disconnect(participantId: UUID? = null): Unit = throw NotImplementedError()
+
+    /**
+     * Mutes the specified participant or self.
+     *
+     * @param participantId an ID of the participant, null for self
+     * @throws MuteException if the operation failed
+     */
+    public suspend fun mute(participantId: UUID? = null): Unit = throw NotImplementedError()
+
+    /**
+     * Unmutes the specified participant or self.
+     *
+     * @param participantId an ID of the participant, null for self
+     * @throws UnmuteException if the operation failed
+     */
+    public suspend fun unmute(participantId: UUID? = null): Unit = throw NotImplementedError()
 
     /**
      * Raises hand of the specified participant or self.
@@ -54,7 +73,7 @@ public interface Roster {
      * @param participantId an ID of the participant, null for self
      * @throws RaiseHandException if the operation failed
      */
-    public suspend fun raiseHand(participantId: UUID? = null)
+    public suspend fun raiseHand(participantId: UUID? = null): Unit = throw NotImplementedError()
 
     /**
      * Lowers hand of the specified participant or self.
@@ -62,12 +81,12 @@ public interface Roster {
      * @param participantId an ID of the participant, null for self
      * @throws LowerHandException if the operation failed
      */
-    public suspend fun lowerHand(participantId: UUID? = null)
+    public suspend fun lowerHand(participantId: UUID? = null): Unit = throw NotImplementedError()
 
     /**
      * Lowers all hands.
      *
      * @throws LowerAllHandsException if the operation failed
      */
-    public suspend fun lowerAllHands()
+    public suspend fun lowerAllHands(): Unit = throw NotImplementedError()
 }

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/UnmuteException.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/UnmuteException.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.conference
+
+/**
+ * Thrown to indicate that unmute failed.
+ *
+ * @property cause a cause of this exception
+ */
+public class UnmuteException @JvmOverloads constructor(cause: Throwable? = null) :
+    RuntimeException("Failed to unmute.", cause)

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/TestParticipantStep.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/TestParticipantStep.kt
@@ -41,11 +41,11 @@ internal open class TestParticipantStep : InfinityService.ParticipantStep {
 
     override fun mute(token: String): Call<Unit> = TODO()
 
-    final override fun mute(token: Token): Call<Unit> = mute(token.token)
+    override fun mute(token: Token): Call<Unit> = mute(token.token)
 
     override fun unmute(token: String): Call<Unit> = TODO()
 
-    final override fun unmute(token: Token): Call<Unit> = unmute(token.token)
+    override fun unmute(token: Token): Call<Unit> = unmute(token.token)
 
     override fun videoMuted(token: String): Call<Unit> = TODO()
 


### PR DESCRIPTION
Additionally, make every property and method in `Roster` have a default implementation that throws `NotImplementedError` to ensure binary compatibility for the consumers and to avoid breaking them (mostly their tests, really) on version upgrades.
