### PR TITLE
chore(conference,registration): deprecate create that accepts java.net.URL

### DIFF
--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
@@ -177,6 +177,10 @@ public class InfinityConference private constructor(
          * @return an instance of [InfinityConference]
          * @throws UnsupportedInfinityException if the version of Infinity is not supported
          */
+        @Deprecated(
+            message = "Use a version of this method that accepts ConferenceStep",
+            replaceWith = ReplaceWith("create(service.newRequest(node).conference(conferenceAlias)), response)"),
+        )
         @JvmStatic
         public fun create(
             service: InfinityService,

--- a/sdk-registration/src/main/kotlin/com/pexip/sdk/registration/infinity/InfinityRegistration.kt
+++ b/sdk-registration/src/main/kotlin/com/pexip/sdk/registration/infinity/InfinityRegistration.kt
@@ -114,6 +114,10 @@ public class InfinityRegistration private constructor(
          * @return an instance of [InfinityRegistration]
          * @throws UnsupportedInfinityException if the version of Infinity is not supported
          */
+        @Deprecated(
+            message = "Use a version of this method that accepts RegistrationStep",
+            replaceWith = ReplaceWith("create(service.newRequest(node).registration(deviceAlias)), response)"),
+        )
         @JvmStatic
         public fun create(
             service: InfinityService,


### PR DESCRIPTION
Ideally we should get rid of `java.net.URL` and other `java.*` imports.
