### PR TITLE
fix(api): remove usage of okhttp3.internal.*

### DIFF
--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/CallStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/CallStepImpl.kt
@@ -30,7 +30,6 @@ import com.pexip.sdk.infinity.CallId
 import kotlinx.serialization.SerializationException
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.internal.EMPTY_REQUEST
 import java.util.concurrent.TimeUnit
 
 internal class CallStepImpl(

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
@@ -39,7 +39,6 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationException
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.internal.EMPTY_REQUEST
 
 internal class ConferenceStepImpl(
     override val requestBuilder: RequestBuilderImpl,

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ParticipantStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ParticipantStepImpl.kt
@@ -33,7 +33,6 @@ import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.SerializationException
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.internal.EMPTY_REQUEST
 
 internal class ParticipantStepImpl(
     override val conferenceStep: ConferenceStepImpl,

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RegistrationStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RegistrationStepImpl.kt
@@ -29,7 +29,6 @@ import com.pexip.sdk.api.infinity.Token
 import kotlinx.serialization.SerializationException
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.internal.EMPTY_REQUEST
 import okio.ByteString.Companion.encodeUtf8
 
 internal class RegistrationStepImpl(

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/Util.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/Util.kt
@@ -88,4 +88,6 @@ internal inline fun <reified T : Any> Request.Builder.withTag(tag: T?) = tag(T::
 internal inline fun <reified T : Any> Request.tagOrElse(block: () -> T) =
     tag(T::class.java) ?: block()
 
+internal val EMPTY_REQUEST = "".toRequestBody()
+
 private val ApplicationJson by lazy { "application/json; charset=utf-8".toMediaType() }


### PR DESCRIPTION
This is required for smooth migration to 5.0.0.
