### PR TITLE
feat(infinity): introduce Node

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -5,6 +5,7 @@
 /assetWizardSettings.xml
 /compiler.xml
 /deploymentTargetDropDown.xml
+/deploymentTargetSelector.xml
 /gradle.xml
 /jarRepositories.xml
 /misc.xml

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -68,6 +68,7 @@ minidns-hla = { module = "org.minidns:minidns-hla", version.ref = "minidns" }
 minidns-android21 = { module = "org.minidns:minidns-android21", version.ref = "minidns" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp" }
 okhttp-sse = { module = "com.squareup.okhttp3:okhttp-sse", version.ref = "okhttp" }
+okhttp-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp" }
 okhttp-logginginterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }

--- a/sample/src/main/kotlin/com/pexip/sdk/sample/di/NetworkModule.kt
+++ b/sample/src/main/kotlin/com/pexip/sdk/sample/di/NetworkModule.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,8 @@ package com.pexip.sdk.sample.di
 
 import android.util.Log
 import com.pexip.sdk.api.infinity.InfinityService
-import com.pexip.sdk.api.infinity.NodeResolver
+import com.pexip.sdk.infinity.NodeResolver
+import com.pexip.sdk.infinity.create
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/sample/src/main/kotlin/com/pexip/sdk/sample/pinrequirement/PinRequirementWorkflow.kt
+++ b/sample/src/main/kotlin/com/pexip/sdk/sample/pinrequirement/PinRequirementWorkflow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,11 @@ package com.pexip.sdk.sample.pinrequirement
 
 import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.InfinityService
-import com.pexip.sdk.api.infinity.NodeResolver
 import com.pexip.sdk.api.infinity.RequestTokenRequest
 import com.pexip.sdk.api.infinity.RequiredPinException
 import com.pexip.sdk.conference.Conference
 import com.pexip.sdk.conference.infinity.InfinityConference
+import com.pexip.sdk.infinity.NodeResolver
 import com.pexip.sdk.sample.settings.SettingsStore
 import com.squareup.workflow1.Snapshot
 import com.squareup.workflow1.StatefulWorkflow
@@ -59,7 +59,7 @@ class PinRequirementWorkflow @Inject constructor(
 
     private fun RenderContext.getNodeSideEffect(props: PinRequirementProps) =
         runningSideEffect(props.toString()) {
-            val action = runCatching { resolver.resolve(props.host).await() }
+            val action = runCatching { resolver.resolve(props.host) }
                 .map { it.asSequence().map(service::newRequest) }
                 .mapCatching { it.first { builder -> builder.status().await() } }
                 .fold(::onNode, ::onError)

--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -568,6 +568,7 @@ public abstract interface class com/pexip/sdk/api/infinity/InfinityService {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/InfinityService$Companion;
 	public static fun create ()Lcom/pexip/sdk/api/infinity/InfinityService;
 	public static fun create (Lokhttp3/OkHttpClient;)Lcom/pexip/sdk/api/infinity/InfinityService;
+	public fun newRequest (Lcom/pexip/sdk/infinity/Node;)Lcom/pexip/sdk/api/infinity/InfinityService$RequestBuilder;
 	public fun newRequest (Ljava/net/URL;)Lcom/pexip/sdk/api/infinity/InfinityService$RequestBuilder;
 }
 

--- a/sdk-api/build.gradle.kts
+++ b/sdk-api/build.gradle.kts
@@ -19,6 +19,7 @@ dependencies {
     testImplementation(project(":sdk-infinity-test"))
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.okhttp.mockwebserver)
+    testImplementation(libs.okhttp.tls)
 }
 
 publishing.publications.withType<MavenPublication> {

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
@@ -22,6 +22,7 @@ import com.pexip.sdk.api.EventSourceFactory
 import com.pexip.sdk.api.infinity.internal.InfinityServiceImpl
 import com.pexip.sdk.infinity.CallId
 import com.pexip.sdk.infinity.LayoutId
+import com.pexip.sdk.infinity.Node
 import com.pexip.sdk.infinity.ParticipantId
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.modules.SerializersModule
@@ -40,6 +41,15 @@ public interface InfinityService {
      * @param node a conferencing node against which to perform requests
      * @throws IllegalArgumentException if the [node] is invalid
      */
+    public fun newRequest(node: Node): RequestBuilder = throw NotImplementedError()
+
+    /**
+     * Creates a new [RequestBuilder].
+     *
+     * @param node a conferencing node against which to perform requests
+     * @throws IllegalArgumentException if the [node] is invalid
+     */
+    @Deprecated("Superseded by a variant that accepts an instance of Node.")
     public fun newRequest(node: URL): RequestBuilder = throw NotImplementedError()
 
     /**

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/NodeResolver.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/NodeResolver.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.pexip.sdk.api.infinity
 
 import com.pexip.sdk.api.Call
@@ -24,7 +26,10 @@ import java.net.URL
 /**
  * A class that can resolve node addresses.
  */
-@Deprecated("Superseded by a suspending variant.")
+@Deprecated(
+    message = "Superseded by a suspending variant.",
+    replaceWith = ReplaceWith("NodeResolver", "com.pexip.sdk.infinity.NodeResolver"),
+)
 public fun interface NodeResolver {
 
     /**
@@ -41,10 +46,24 @@ public fun interface NodeResolver {
 
         @JvmStatic
         @JvmOverloads
+        @Deprecated(
+            message = "Superseded by a suspending variant.",
+            replaceWith = ReplaceWith(
+                expression = "NodeResolver.Companion.create(dnssec)",
+                imports = ["com.pexip.sdk.infinity.NodeResolver", "com.pexip.sdk.infinity.create"],
+            ),
+        )
         public fun create(dnssec: Boolean = false): NodeResolver =
             create(if (dnssec) DnssecResolverApi.INSTANCE else ResolverApi.INSTANCE)
 
         @JvmStatic
+        @Deprecated(
+            message = "Superseded by a suspending variant.",
+            replaceWith = ReplaceWith(
+                expression = "NodeResolver.Companion.create(api)",
+                imports = ["com.pexip.sdk.infinity.NodeResolver", "com.pexip.sdk.infinity.create"],
+            ),
+        )
         public fun create(api: ResolverApi): NodeResolver = RealNodeResolver(api)
     }
 }

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/CallStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/CallStepImpl.kt
@@ -41,7 +41,7 @@ internal class CallStepImpl(
         client = client,
         request = Request.Builder()
             .post(json.encodeToRequestBody(request))
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 call(callId)
@@ -58,7 +58,7 @@ internal class CallStepImpl(
             .build(),
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 call(callId)
@@ -75,7 +75,7 @@ internal class CallStepImpl(
             .build(),
         request = Request.Builder()
             .post(json.encodeToRequestBody(request))
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 call(callId)
@@ -90,7 +90,7 @@ internal class CallStepImpl(
         client = client,
         request = Request.Builder()
             .post(json.encodeToRequestBody(request))
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 call(callId)
@@ -105,7 +105,7 @@ internal class CallStepImpl(
         client = client,
         request = Request.Builder()
             .post(json.encodeToRequestBody(request))
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 call(callId)

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
@@ -51,7 +51,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .post(json.encodeToRequestBody(request))
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("request_token")
             }
@@ -67,7 +67,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .post(json.encodeToRequestBody(request))
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("request_token")
             }
@@ -81,7 +81,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("refresh_token")
             }
@@ -94,7 +94,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("release_token")
             }
@@ -107,7 +107,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .post(json.encodeToRequestBody(request))
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("message")
             }
@@ -120,7 +120,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .get()
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("available_layouts")
             }
@@ -133,7 +133,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .get()
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("layout_svgs")
             }
@@ -147,7 +147,7 @@ internal class ConferenceStepImpl(
             client = client,
             request = Request.Builder()
                 .post(json.encodeToRequestBody(TransformLayoutRequestSerializer, request))
-                .url(node) {
+                .url(url) {
                     conference(conferenceAlias)
                     addPathSegment("transform_layout")
                 }
@@ -160,7 +160,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .get()
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("theme")
                 addPathSegment("")
@@ -172,7 +172,7 @@ internal class ConferenceStepImpl(
 
     override fun theme(path: String, token: Token): String {
         require(path.isNotBlank()) { "path is blank." }
-        return node.newApiClientV2Builder()
+        return url.newApiClientV2Builder()
             .conference(conferenceAlias)
             .addPathSegment("theme")
             .addPathSegment(path)
@@ -184,7 +184,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("clearallbuzz")
             }
@@ -197,7 +197,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("lock")
             }
@@ -210,7 +210,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("unlock")
             }
@@ -223,7 +223,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("muteguests")
             }
@@ -236,7 +236,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("unmuteguests")
             }
@@ -249,7 +249,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("disconnect")
             }
@@ -262,7 +262,7 @@ internal class ConferenceStepImpl(
         client = client,
         request = Request.Builder()
             .get()
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 addPathSegment("events")
             }

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/InfinityServiceImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/InfinityServiceImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,8 @@ package com.pexip.sdk.api.infinity.internal
 
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.InfinityService.RequestBuilder
+import com.pexip.sdk.infinity.Node
 import kotlinx.serialization.json.Json
-import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import okhttp3.OkHttpClient
 import java.net.URL
 
@@ -27,8 +27,9 @@ internal class InfinityServiceImpl(
     override val json: Json,
 ) : InfinityService, InfinityServiceImplScope {
 
-    override fun newRequest(node: URL): RequestBuilder = RequestBuilderImpl(
-        infinityService = this,
-        node = requireNotNull(node.toHttpUrlOrNull()) { "Invalid node address." },
-    )
+    override fun newRequest(node: Node): RequestBuilder = RequestBuilderImpl(this, node)
+
+    @Deprecated("Superseded by a variant that accepts an instance of Node.")
+    override fun newRequest(node: URL): RequestBuilder =
+        RequestBuilderImpl(this, Node(node.host, node.port))
 }

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ParticipantStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ParticipantStepImpl.kt
@@ -45,7 +45,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(json.encodeToRequestBody(request))
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("calls")
@@ -59,7 +59,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(json.encodeToRequestBody(request))
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("dtmf")
@@ -73,7 +73,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("mute")
@@ -87,7 +87,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("unmute")
@@ -101,7 +101,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("video_muted")
@@ -115,7 +115,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("video_unmuted")
@@ -129,7 +129,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("take_floor")
@@ -143,7 +143,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("release_floor")
@@ -157,7 +157,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(json.encodeToRequestBody(request))
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("message")
@@ -174,7 +174,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(json.encodeToRequestBody(request))
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("preferred_aspect_ratio")
@@ -188,7 +188,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("buzz")
@@ -202,7 +202,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("clearbuzz")
@@ -216,7 +216,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("spotlighton")
@@ -230,7 +230,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("spotlightoff")
@@ -244,7 +244,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("unlock")
@@ -258,7 +258,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("disconnect")
@@ -272,7 +272,7 @@ internal class ParticipantStepImpl(
         client = client,
         request = Request.Builder()
             .post(json.encodeToRequestBody(request))
-            .url(node) {
+            .url(url) {
                 conference(conferenceAlias)
                 participant(participantId)
                 addPathSegment("role")

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RealNodeResolver.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RealNodeResolver.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.pexip.sdk.api.infinity.internal
 
 import com.pexip.sdk.api.Call

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RegistrationStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RegistrationStepImpl.kt
@@ -47,7 +47,7 @@ internal class RegistrationStepImpl(
             client = client,
             request = Request.Builder()
                 .post(EMPTY_REQUEST)
-                .url(node) {
+                .url(url) {
                     registration(deviceAlias)
                     addPathSegment("request_token")
                 }
@@ -61,7 +61,7 @@ internal class RegistrationStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 registration(deviceAlias)
                 addPathSegment("refresh_token")
             }
@@ -74,7 +74,7 @@ internal class RegistrationStepImpl(
         client = client,
         request = Request.Builder()
             .post(EMPTY_REQUEST)
-            .url(node) {
+            .url(url) {
                 registration(deviceAlias)
                 addPathSegment("release_token")
             }
@@ -87,7 +87,7 @@ internal class RegistrationStepImpl(
         client = client,
         request = Request.Builder()
             .get()
-            .url(node) {
+            .url(url) {
                 registration(deviceAlias)
                 addPathSegment("events")
             }
@@ -101,7 +101,7 @@ internal class RegistrationStepImpl(
             client = client,
             request = Request.Builder()
                 .get()
-                .url(node) {
+                .url(url) {
                     registration()
                     if (query.isNotBlank()) {
                         addQueryParameter("q", query.trim())

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RequestBuilderImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RequestBuilderImpl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,22 +18,29 @@ package com.pexip.sdk.api.infinity.internal
 import com.pexip.sdk.api.Call
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.NoSuchNodeException
+import com.pexip.sdk.infinity.Node
 import okhttp3.HttpUrl
 import okhttp3.Request
 import okhttp3.Response
 
 internal class RequestBuilderImpl(
     override val infinityService: InfinityServiceImpl,
-    override val node: HttpUrl,
+    node: Node,
 ) : InfinityService.RequestBuilder,
     RequestBuilderImplScope,
     InfinityServiceImplScope by infinityService {
+
+    override val url: HttpUrl = HttpUrl.Builder()
+        .scheme("https")
+        .host(node.host)
+        .port(node.port)
+        .build()
 
     override fun status(): Call<Boolean> = RealCall(
         client = client,
         request = Request.Builder()
             .get()
-            .url(node) { addPathSegment("status") }
+            .url(url) { addPathSegment("status") }
             .build(),
         mapper = ::parseStatus,
     )

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/CallStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/CallStepTest.kt
@@ -30,10 +30,9 @@ import com.pexip.sdk.infinity.test.nextString
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import okhttp3.OkHttpClient
+import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule
-import java.net.URL
 import kotlin.properties.Delegates
 import kotlin.random.Random
 import kotlin.test.BeforeTest
@@ -42,9 +41,12 @@ import kotlin.test.Test
 internal class CallStepTest {
 
     @get:Rule
-    val server = MockWebServer()
+    val rule = SecureMockWebServerRule()
 
-    private lateinit var node: URL
+    private val server get() = rule.server
+    private val client get() = rule.client
+
+    private lateinit var node: HttpUrl
     private lateinit var conferenceAlias: String
     private lateinit var json: Json
     private lateinit var token: Token
@@ -55,14 +57,14 @@ internal class CallStepTest {
 
     @BeforeTest
     fun setUp() {
-        node = server.url("/").toUrl()
+        node = server.url("/")
         conferenceAlias = Random.nextString()
         participantId = Random.nextParticipantId()
         callId = Random.nextCallId()
-        json = Json { ignoreUnknownKeys = true }
-        val service = InfinityService.create(OkHttpClient(), json)
+        json = InfinityService.Json
         token = Random.nextFakeToken()
-        step = service.newRequest(node)
+        step = InfinityService.create(client, json)
+            .newRequest(node)
             .conference(conferenceAlias)
             .participant(participantId)
             .call(callId)

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/NodeResolverTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/NodeResolverTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("DEPRECATION")
+
 package com.pexip.sdk.api.infinity
 
 import org.junit.runner.RunWith

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ParticipantStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ParticipantStepTest.kt
@@ -28,10 +28,9 @@ import com.pexip.sdk.infinity.test.nextString
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import okhttp3.OkHttpClient
+import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule
-import java.net.URL
 import kotlin.properties.Delegates
 import kotlin.random.Random
 import kotlin.test.BeforeTest
@@ -42,9 +41,12 @@ import kotlin.test.assertFailsWith
 internal class ParticipantStepTest {
 
     @get:Rule
-    val server = MockWebServer()
+    val rule = SecureMockWebServerRule()
 
-    private lateinit var node: URL
+    private val server get() = rule.server
+    private val client get() = rule.client
+
+    private lateinit var node: HttpUrl
     private lateinit var conferenceAlias: String
     private lateinit var json: Json
     private lateinit var token: Token
@@ -54,13 +56,13 @@ internal class ParticipantStepTest {
 
     @BeforeTest
     fun setUp() {
-        node = server.url("/").toUrl()
+        node = server.url("/")
         conferenceAlias = Random.nextString()
         participantId = Random.nextParticipantId()
-        json = Json { ignoreUnknownKeys = true }
-        val service = InfinityService.create(OkHttpClient(), json)
+        json = InfinityService.Json
         token = Random.nextFakeToken()
-        step = service.newRequest(node)
+        step = InfinityService.create(client, json)
+            .newRequest(node)
             .conference(conferenceAlias)
             .participant(participantId)
     }

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/RegistrationStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/RegistrationStepTest.kt
@@ -19,10 +19,9 @@ import com.pexip.sdk.infinity.test.nextRegistrationId
 import com.pexip.sdk.infinity.test.nextString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import okhttp3.OkHttpClient
+import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule
-import java.net.URL
 import kotlin.random.Random
 import kotlin.random.nextInt
 import kotlin.test.BeforeTest
@@ -34,9 +33,12 @@ import kotlin.time.Duration.Companion.seconds
 internal class RegistrationStepTest {
 
     @get:Rule
-    val server = MockWebServer()
+    val rule = SecureMockWebServerRule()
 
-    private lateinit var node: URL
+    private val server get() = rule.server
+    private val client get() = rule.client
+
+    private lateinit var node: HttpUrl
     private lateinit var deviceAlias: String
     private lateinit var username: String
     private lateinit var password: String
@@ -46,14 +48,15 @@ internal class RegistrationStepTest {
 
     @BeforeTest
     fun setUp() {
-        node = server.url("/").toUrl()
+        node = server.url("/")
         deviceAlias = Random.nextString()
         username = Random.nextString()
         password = Random.nextString()
-        json = Json { ignoreUnknownKeys = true }
-        val service = InfinityService.create(OkHttpClient(), json)
+        json = InfinityService.Json
         token = Random.nextFakeToken()
-        step = service.newRequest(node).registration(deviceAlias)
+        step = InfinityService.create(client, json)
+            .newRequest(node)
+            .registration(deviceAlias)
     }
 
     @Test

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/RequestBuilderTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/RequestBuilderTest.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,10 +15,9 @@
  */
 package com.pexip.sdk.api.infinity
 
+import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Rule
-import java.net.URL
-import kotlin.properties.Delegates
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
@@ -28,17 +27,18 @@ import kotlin.test.assertTrue
 internal class RequestBuilderTest {
 
     @get:Rule
-    val server = MockWebServer()
+    val rule = SecureMockWebServerRule()
 
+    private val server get() = rule.server
+    private val client get() = rule.client
+
+    private lateinit var node: HttpUrl
     private lateinit var builder: InfinityService.RequestBuilder
-
-    private var node: URL by Delegates.notNull()
 
     @BeforeTest
     fun setUp() {
-        node = server.url("/").toUrl()
-        val service = InfinityService.create()
-        builder = service.newRequest(node)
+        node = server.url("/")
+        builder = InfinityService.create(client).newRequest(node)
     }
 
     @Test

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/SecureMockWebServerRule.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/SecureMockWebServerRule.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.api.infinity
+
+import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.tls.HandshakeCertificates
+import okhttp3.tls.HeldCertificate
+import org.junit.rules.ExternalResource
+import java.net.InetAddress
+
+class SecureMockWebServerRule : ExternalResource() {
+
+    val server = MockWebServer()
+
+    lateinit var client: OkHttpClient
+        private set
+
+    override fun before() {
+        val localhost = InetAddress.getByName("localhost")
+        val certificate = HeldCertificate.Builder()
+            .addSubjectAlternativeName(localhost.canonicalHostName)
+            .build()
+        val serverCertificate = HandshakeCertificates.Builder()
+            .heldCertificate(certificate)
+            .build()
+        val clientCertificate = HandshakeCertificates.Builder()
+            .addTrustedCertificate(certificate.certificate)
+            .build()
+        server.useHttps(
+            sslSocketFactory = serverCertificate.sslSocketFactory(),
+            tunnelProxy = false,
+        )
+        server.start(inetAddress = localhost, port = 0)
+        client = OkHttpClient.Builder()
+            .sslSocketFactory(clientCertificate.sslSocketFactory(), clientCertificate.trustManager)
+            .build()
+    }
+
+    override fun after() {
+        server.shutdown()
+    }
+}

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/Util.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/Util.kt
@@ -15,11 +15,11 @@
  */
 package com.pexip.sdk.api.infinity
 
+import com.pexip.sdk.infinity.Node
 import com.pexip.sdk.infinity.test.nextString
 import kotlinx.serialization.DeserializationStrategy
 import kotlinx.serialization.json.Json
 import okhttp3.HttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
@@ -28,7 +28,6 @@ import okio.ByteString.Companion.encodeUtf8
 import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
-import java.net.URL
 import kotlin.random.Random
 import kotlin.random.nextInt
 import kotlin.test.assertEquals
@@ -55,6 +54,8 @@ internal fun Random.nextMessageRequest() = MessageRequest(
     payload = nextString(),
     type = nextString(),
 )
+
+internal fun InfinityService.newRequest(url: HttpUrl) = newRequest(Node(url.host, url.port))
 
 internal inline fun MockWebServer.enqueue(block: MockResponse.() -> Unit) =
     enqueue(MockResponse().apply(block))
@@ -85,9 +86,6 @@ internal fun <T> RecordedRequest.assertPost(
     assertContentType("application/json; charset=utf-8")
     assertEquals(request, json.decodeFromString(serializer, body.readUtf8()))
 }
-
-internal fun RecordedRequest.assertRequestUrl(url: URL, block: HttpUrl.Builder.() -> Unit) =
-    assertEquals(url.toString().toHttpUrl().newBuilder().apply(block).build(), requestUrl)
 
 internal fun RecordedRequest.assertRequestUrl(url: HttpUrl, block: HttpUrl.Builder.() -> Unit) =
     assertEquals(url.newBuilder().apply(block).build(), requestUrl)

--- a/sdk-infinity/api/sdk-infinity.api
+++ b/sdk-infinity/api/sdk-infinity.api
@@ -58,6 +58,34 @@ public final class com/pexip/sdk/infinity/LayoutId$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/pexip/sdk/infinity/Node {
+	public fun <init> (Ljava/lang/String;I)V
+	public synthetic fun <init> (Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()I
+	public final fun copy (Ljava/lang/String;I)Lcom/pexip/sdk/infinity/Node;
+	public static synthetic fun copy$default (Lcom/pexip/sdk/infinity/Node;Ljava/lang/String;IILjava/lang/Object;)Lcom/pexip/sdk/infinity/Node;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getHost ()Ljava/lang/String;
+	public final fun getPort ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/pexip/sdk/infinity/NodeResolver {
+	public static final field Companion Lcom/pexip/sdk/infinity/NodeResolver$Companion;
+	public abstract fun resolve (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/pexip/sdk/infinity/NodeResolver$Companion {
+}
+
+public final class com/pexip/sdk/infinity/NodeResolver_jvmKt {
+	public static final fun create (Lcom/pexip/sdk/infinity/NodeResolver$Companion;Lorg/minidns/hla/ResolverApi;)Lcom/pexip/sdk/infinity/NodeResolver;
+	public static final fun create (Lcom/pexip/sdk/infinity/NodeResolver$Companion;Z)Lcom/pexip/sdk/infinity/NodeResolver;
+	public static synthetic fun create$default (Lcom/pexip/sdk/infinity/NodeResolver$Companion;ZILjava/lang/Object;)Lcom/pexip/sdk/infinity/NodeResolver;
+}
+
 public final class com/pexip/sdk/infinity/ParticipantId {
 	public static final field Companion Lcom/pexip/sdk/infinity/ParticipantId$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/pexip/sdk/infinity/ParticipantId;

--- a/sdk-infinity/build.gradle.kts
+++ b/sdk-infinity/build.gradle.kts
@@ -6,11 +6,15 @@ plugins {
 kotlin {
     jvm()
     sourceSets {
-        commonMain {
-            dependencies {
-                api(project(":sdk-core"))
-                api(libs.kotlinx.serialization.core)
-            }
+        commonMain.dependencies {
+            api(project(":sdk-core"))
+            api(libs.kotlinx.serialization.core)
+        }
+        commonTest.dependencies {
+            implementation(libs.kotlinx.coroutines.test)
+        }
+        jvmMain.dependencies {
+            api(libs.minidns.hla)
         }
     }
 }

--- a/sdk-infinity/src/commonMain/kotlin/com/pexip/sdk/infinity/Node.kt
+++ b/sdk-infinity/src/commonMain/kotlin/com/pexip/sdk/infinity/Node.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Pexip AS
+ * Copyright 2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.pexip.sdk.api.infinity.internal
+package com.pexip.sdk.infinity
 
-import okhttp3.HttpUrl
+/**
+ * An Infinity node.
+ *
+ * @property host a hostname of this node
+ * @property port a port of this node
+ */
+public data class Node(val host: String, val port: Int = 443) {
 
-internal sealed interface RequestBuilderImplScope : InfinityServiceImplScope {
-
-    val url: HttpUrl
+    init {
+        require(host.isNotBlank()) { "host is blank." }
+        require(port in 1..65535) { "invalid port: $port." }
+    }
 }

--- a/sdk-infinity/src/commonMain/kotlin/com/pexip/sdk/infinity/NodeResolver.kt
+++ b/sdk-infinity/src/commonMain/kotlin/com/pexip/sdk/infinity/NodeResolver.kt
@@ -13,18 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.pexip.sdk.api.infinity
-
-import com.pexip.sdk.api.Call
-import com.pexip.sdk.api.infinity.internal.RealNodeResolver
-import org.minidns.hla.DnssecResolverApi
-import org.minidns.hla.ResolverApi
-import java.net.URL
+package com.pexip.sdk.infinity
 
 /**
  * A class that can resolve node addresses.
  */
-@Deprecated("Superseded by a suspending variant.")
 public fun interface NodeResolver {
 
     /**
@@ -33,18 +26,16 @@ public fun interface NodeResolver {
      * for the recommended flow.
      *
      * @param host a host to use to resolve node addresses
-     * @return a [Call]
+     * @return a list of nodes
      */
-    public fun resolve(host: String): Call<List<URL>>
+    public suspend fun resolve(host: String): List<Node>
 
-    public companion object {
-
-        @JvmStatic
-        @JvmOverloads
-        public fun create(dnssec: Boolean = false): NodeResolver =
-            create(if (dnssec) DnssecResolverApi.INSTANCE else ResolverApi.INSTANCE)
-
-        @JvmStatic
-        public fun create(api: ResolverApi): NodeResolver = RealNodeResolver(api)
-    }
+    public companion object
 }
+
+/**
+ * Creates a new instance of [NodeResolver].
+ *
+ * @param dnssec whether to use DNSSEC or not
+ */
+public expect fun NodeResolver.Companion.create(dnssec: Boolean = false): NodeResolver

--- a/sdk-infinity/src/commonTest/kotlin/com/pexip/sdk/infinity/NodeResolverTest.kt
+++ b/sdk-infinity/src/commonTest/kotlin/com/pexip/sdk/infinity/NodeResolverTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022-2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.infinity
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.tableOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class NodeResolverTest {
+
+    private lateinit var resolver: NodeResolver
+
+    @BeforeTest
+    fun setUp() {
+        resolver = NodeResolver.create()
+    }
+
+    @Test
+    fun `returns a list of nodes`() {
+        tableOf("host", "nodes")
+            .row("pexip.com", listOf(Node("pexipdemo.com")))
+            .row("google.com", listOf(Node("google.com")))
+            .row("b.c", listOf())
+            .forAll(::`returns a list of nodes`)
+    }
+
+    private fun `returns a list of nodes`(host: String, nodes: List<Node>) = runTest {
+        assertThat(resolver.resolve(host), "nodes").isEqualTo(nodes)
+    }
+}

--- a/sdk-infinity/src/jvmMain/kotlin/com/pexip/sdk/infinity/NodeResolver.jvm.kt
+++ b/sdk-infinity/src/jvmMain/kotlin/com/pexip/sdk/infinity/NodeResolver.jvm.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.infinity
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.minidns.hla.DnssecResolverApi
+import org.minidns.hla.ResolverApi
+import java.net.InetAddress
+import java.net.UnknownHostException
+
+/**
+ * Creates a new instance of [NodeResolver] backed by [ResolverApi].
+ *
+ * @param dnssec whether to use DNSSEC
+ */
+public actual fun NodeResolver.Companion.create(dnssec: Boolean): NodeResolver =
+    NodeResolver.create(if (dnssec) DnssecResolverApi.INSTANCE else ResolverApi.INSTANCE)
+
+/**
+ * Creates a new instance of [NodeResolver] backed by [ResolverApi].
+ *
+ * @param api an instance of [ResolverApi]
+ */
+public fun NodeResolver.Companion.create(api: ResolverApi): NodeResolver =
+    object : NodeResolver {
+
+        override suspend fun resolve(host: String): List<Node> = withContext(Dispatchers.IO) {
+            resolveSrvRecords(host).ifEmpty { resolveARecord(host) }
+        }
+
+        private fun resolveSrvRecords(host: String): List<Node> {
+            val result = api.resolveSrv("_pexapp._tcp.$host")
+            if (!result.wasSuccessful()) return emptyList()
+            return result.sortedSrvResolvedAddresses.map { Node(it.srv.target.ace, it.srv.port) }
+        }
+
+        private fun resolveARecord(host: String) = try {
+            val address = InetAddress.getByName(host)
+            listOf(Node(address.hostName))
+        } catch (e: UnknownHostException) {
+            emptyList()
+        }
+    }


### PR DESCRIPTION
This PR adds a `Node` that represents the address of the Infinity node
that the SDK will communicate with.

Note that while the `Node` includes `port`, in real world use it will
almost exclusively be 443 since Infinity forces you to use TLS over said
port. It's exposed here to allow testing against `MockWebServer`.

We also added a suspending `NodeResolver` that will return a `Node`
list and deprecated the one found in `:sdk-api` module.
