### PR TITLE
feat(api): add parameters used to create steps to instances

### DIFF
--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -579,6 +579,7 @@ public abstract interface class com/pexip/sdk/api/infinity/InfinityService$CallS
 	public fun ack (Ljava/lang/String;)Lcom/pexip/sdk/api/Call;
 	public fun dtmf (Lcom/pexip/sdk/api/infinity/DtmfRequest;Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun dtmf (Lcom/pexip/sdk/api/infinity/DtmfRequest;Ljava/lang/String;)Lcom/pexip/sdk/api/Call;
+	public fun getCallId-XxhQU_c ()Ljava/lang/String;
 	public fun getParticipantStep ()Lcom/pexip/sdk/api/infinity/InfinityService$ParticipantStep;
 	public fun newCandidate (Lcom/pexip/sdk/api/infinity/NewCandidateRequest;Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun newCandidate (Lcom/pexip/sdk/api/infinity/NewCandidateRequest;Ljava/lang/String;)Lcom/pexip/sdk/api/Call;
@@ -600,6 +601,7 @@ public abstract interface class com/pexip/sdk/api/infinity/InfinityService$Confe
 	public fun disconnect (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun events (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/EventSourceFactory;
 	public fun events (Ljava/lang/String;)Lcom/pexip/sdk/api/EventSourceFactory;
+	public fun getConferenceAlias ()Ljava/lang/String;
 	public fun getRequestBuilder ()Lcom/pexip/sdk/api/infinity/InfinityService$RequestBuilder;
 	public fun layoutSvgs (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun layoutSvgs (Ljava/lang/String;)Lcom/pexip/sdk/api/Call;
@@ -637,6 +639,7 @@ public abstract interface class com/pexip/sdk/api/infinity/InfinityService$Parti
 	public fun dtmf (Lcom/pexip/sdk/api/infinity/DtmfRequest;Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun dtmf (Lcom/pexip/sdk/api/infinity/DtmfRequest;Ljava/lang/String;)Lcom/pexip/sdk/api/Call;
 	public fun getConferenceStep ()Lcom/pexip/sdk/api/infinity/InfinityService$ConferenceStep;
+	public fun getParticipantId-UyOe1Tk ()Ljava/lang/String;
 	public fun message (Lcom/pexip/sdk/api/infinity/MessageRequest;Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun message (Lcom/pexip/sdk/api/infinity/MessageRequest;Ljava/lang/String;)Lcom/pexip/sdk/api/Call;
 	public fun mute (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
@@ -662,6 +665,7 @@ public abstract interface class com/pexip/sdk/api/infinity/InfinityService$Parti
 public abstract interface class com/pexip/sdk/api/infinity/InfinityService$RegistrationStep {
 	public fun events (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/EventSourceFactory;
 	public fun events (Ljava/lang/String;)Lcom/pexip/sdk/api/EventSourceFactory;
+	public fun getDeviceAlias ()Ljava/lang/String;
 	public fun getRequestBuilder ()Lcom/pexip/sdk/api/infinity/InfinityService$RequestBuilder;
 	public fun refreshToken (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun refreshToken (Ljava/lang/String;)Lcom/pexip/sdk/api/Call;
@@ -677,6 +681,7 @@ public abstract interface class com/pexip/sdk/api/infinity/InfinityService$Regis
 public abstract interface class com/pexip/sdk/api/infinity/InfinityService$RequestBuilder {
 	public fun conference (Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/InfinityService$ConferenceStep;
 	public fun getInfinityService ()Lcom/pexip/sdk/api/infinity/InfinityService;
+	public fun getNode ()Lcom/pexip/sdk/infinity/Node;
 	public fun registration (Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/InfinityService$RegistrationStep;
 	public fun status ()Lcom/pexip/sdk/api/Call;
 }

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
@@ -54,12 +54,19 @@ public interface InfinityService {
 
     /**
      * Represents the [Other miscellaneous requests](https://docs.pexip.com/api_client/api_rest.htm?Highlight=api#misc) section.
-     *
-     * @property infinityService the [InfinityService] that produced this [RequestBuilder]
      */
     public interface RequestBuilder {
 
+        /**
+         * The Infinity service that produced this request builder.
+         */
         public val infinityService: InfinityService
+            get() = throw NotImplementedError()
+
+        /**
+         * A node that this request builder will use.
+         */
+        public val node: Node
             get() = throw NotImplementedError()
 
         /**
@@ -89,12 +96,19 @@ public interface InfinityService {
 
     /**
      * Represents the [Conference control functions](https://docs.pexip.com/api_client/api_rest.htm?Highlight=api#conference) section.
-     *
-     * @property requestBuilder the [RequestBuilder] that produced this [ConferenceStep]
      */
     public interface ConferenceStep {
 
+        /**
+         * The request builder that produced this conference step.
+         */
         public val requestBuilder: RequestBuilder
+            get() = throw NotImplementedError()
+
+        /**
+         * A conference alias that this conference step will use.
+         */
+        public val conferenceAlias: String
             get() = throw NotImplementedError()
 
         /**
@@ -459,12 +473,19 @@ public interface InfinityService {
 
     /**
      * Represents the registration control functions section.
-     *
-     * @property requestBuilder the [RequestBuilder] that produced this [RegistrationStep]
      */
     public interface RegistrationStep {
 
+        /**
+         * The request builder that produced this registration step.
+         */
         public val requestBuilder: RequestBuilder
+            get() = throw NotImplementedError()
+
+        /**
+         * The device alias that this registration step will use.
+         */
+        public val deviceAlias: String
             get() = throw NotImplementedError()
 
         /**
@@ -605,7 +626,16 @@ public interface InfinityService {
      */
     public interface ParticipantStep {
 
+        /**
+         * The conference step that produced this participant step.
+         */
         public val conferenceStep: ConferenceStep
+            get() = throw NotImplementedError()
+
+        /**
+         * A participant ID that this participant step will use.
+         */
+        public val participantId: ParticipantId
             get() = throw NotImplementedError()
 
         /**
@@ -971,12 +1001,19 @@ public interface InfinityService {
 
     /**
      * Represents the [Call functions](https://docs.pexip.com/api_client/api_rest.htm?Highlight=api#call_functions) section.
-     *
-     * @property participantStep the [ParticipantStep] that produced this [CallStep]
      */
     public interface CallStep {
 
+        /**
+         * The participant step that produced this call step.
+         */
         public val participantStep: ParticipantStep
+            get() = throw NotImplementedError()
+
+        /**
+         * A call ID that this call step will use.
+         */
+        public val callId: CallId
             get() = throw NotImplementedError()
 
         /**

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/CallStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/CallStepImpl.kt
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit
 
 internal class CallStepImpl(
     override val participantStep: ParticipantStepImpl,
-    private val callId: CallId,
+    override val callId: CallId,
 ) : InfinityService.CallStep, ParticipantStepImplScope by participantStep {
 
     override fun newCandidate(request: NewCandidateRequest, token: Token): Call<Unit> = RealCall(

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RegistrationStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RegistrationStepImpl.kt
@@ -33,7 +33,7 @@ import okio.ByteString.Companion.encodeUtf8
 
 internal class RegistrationStepImpl(
     override val requestBuilder: RequestBuilderImpl,
-    private val deviceAlias: String,
+    override val deviceAlias: String,
 ) : InfinityService.RegistrationStep, RequestBuilderImplScope by requestBuilder {
 
     override fun requestToken(

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RequestBuilderImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RequestBuilderImpl.kt
@@ -25,7 +25,7 @@ import okhttp3.Response
 
 internal class RequestBuilderImpl(
     override val infinityService: InfinityServiceImpl,
-    node: Node,
+    override val node: Node,
 ) : InfinityService.RequestBuilder,
     RequestBuilderImplScope,
     InfinityServiceImplScope by infinityService {

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/CallStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/CallStepTest.kt
@@ -71,6 +71,11 @@ internal class CallStepTest {
     }
 
     @Test
+    fun `callId returns the correct value`() {
+        assertThat(step::callId).isEqualTo(callId)
+    }
+
+    @Test
     fun `newCandidate throws IllegalStateException`() = runTest {
         server.enqueue { setResponseCode(500) }
         val request = Random.nextNewCandidateRequest()
@@ -98,6 +103,7 @@ internal class CallStepTest {
         val request = Random.nextNewCandidateRequest()
         assertFailure { step.newCandidate(request, token).await() }
             .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
         server.verifyNewCandidate(request, token)
     }
 
@@ -111,6 +117,7 @@ internal class CallStepTest {
         val request = Random.nextNewCandidateRequest()
         assertFailure { step.newCandidate(request, token).await() }
             .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
         server.verifyNewCandidate(request, token)
     }
 
@@ -158,7 +165,9 @@ internal class CallStepTest {
             null -> step.ack(token)
             else -> step.ack(request, token)
         }
-        assertFailure { call.await() }.isInstanceOf<NoSuchConferenceException>()
+        assertFailure { call.await() }
+            .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
         server.verifyAck(request, token)
     }
 
@@ -174,7 +183,9 @@ internal class CallStepTest {
             null -> step.ack(token)
             else -> step.ack(request, token)
         }
-        assertFailure { call.await() }.isInstanceOf<InvalidTokenException>()
+        assertFailure { call.await() }
+            .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
         server.verifyAck(request, token)
     }
 
@@ -272,6 +283,7 @@ internal class CallStepTest {
         val request = DtmfRequest(Random.nextDigits(8))
         assertFailure { step.dtmf(request, token).await() }
             .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
         server.verifyDtmf(request, token)
     }
 
@@ -283,7 +295,9 @@ internal class CallStepTest {
             setBody(json.encodeToString(Box(message)))
         }
         val request = DtmfRequest(Random.nextDigits(8))
-        assertFailure { step.dtmf(request, token).await() }.isInstanceOf<InvalidTokenException>()
+        assertFailure { step.dtmf(request, token).await() }
+            .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
         server.verifyDtmf(request, token)
     }
 

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
@@ -76,6 +76,11 @@ internal class ConferenceStepTest {
     }
 
     @Test
+    fun `conferenceAlias returns the correct value`() {
+        assertThat(step::conferenceAlias).isEqualTo(conferenceAlias)
+    }
+
+    @Test
     fun `requestToken throws IllegalStateException`() {
         server.enqueue { setResponseCode(500) }
         val request = RequestTokenRequest()
@@ -336,6 +341,7 @@ internal class ConferenceStepTest {
         }
         assertFailure { step.releaseToken(token).execute() }
             .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
         server.verifyReleaseToken(token)
     }
 
@@ -346,7 +352,9 @@ internal class ConferenceStepTest {
             setResponseCode(403)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.releaseToken(token).execute() }.isInstanceOf<InvalidTokenException>()
+        assertFailure { step.releaseToken(token).execute() }
+            .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
         server.verifyReleaseToken(token)
     }
 
@@ -388,6 +396,7 @@ internal class ConferenceStepTest {
         val request = Random.nextMessageRequest()
         assertFailure { step.message(request, token).execute() }
             .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
         server.verifyMessage(request, token)
     }
 
@@ -401,6 +410,7 @@ internal class ConferenceStepTest {
         val request = Random.nextMessageRequest()
         assertFailure { step.message(request, token).execute() }
             .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
         server.verifyMessage(request, token)
     }
 
@@ -654,7 +664,9 @@ internal class ConferenceStepTest {
             setResponseCode(404)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.theme(token).execute() }.isInstanceOf<NoSuchConferenceException>()
+        assertFailure { step.theme(token).execute() }
+            .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
         server.verifyTheme(token)
     }
 
@@ -665,7 +677,9 @@ internal class ConferenceStepTest {
             setResponseCode(403)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.theme(token).execute() }.isInstanceOf<InvalidTokenException>()
+        assertFailure { step.theme(token).execute() }
+            .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
         server.verifyTheme(token)
     }
 
@@ -732,7 +746,9 @@ internal class ConferenceStepTest {
             setResponseCode(404)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.clearAllBuzz(token).await() }.isInstanceOf<NoSuchConferenceException>()
+        assertFailure { step.clearAllBuzz(token).await() }
+            .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
         server.verifyClearAllBuzz(token)
     }
 
@@ -743,7 +759,9 @@ internal class ConferenceStepTest {
             setResponseCode(403)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.clearAllBuzz(token).await() }.isInstanceOf<InvalidTokenException>()
+        assertFailure { step.clearAllBuzz(token).await() }
+            .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
         server.verifyClearAllBuzz(token)
     }
 
@@ -781,7 +799,9 @@ internal class ConferenceStepTest {
             setResponseCode(404)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.lock(token).await() }.isInstanceOf<NoSuchConferenceException>()
+        assertFailure { step.lock(token).await() }
+            .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
         server.verifyLock(token)
     }
 
@@ -792,7 +812,9 @@ internal class ConferenceStepTest {
             setResponseCode(403)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.lock(token).await() }.isInstanceOf<InvalidTokenException>()
+        assertFailure { step.lock(token).await() }
+            .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
         server.verifyLock(token)
     }
 
@@ -830,7 +852,9 @@ internal class ConferenceStepTest {
             setResponseCode(404)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.unlock(token).await() }.isInstanceOf<NoSuchConferenceException>()
+        assertFailure { step.unlock(token).await() }
+            .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
         server.verifyUnlock(token)
     }
 
@@ -841,7 +865,9 @@ internal class ConferenceStepTest {
             setResponseCode(403)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.unlock(token).await() }.isInstanceOf<InvalidTokenException>()
+        assertFailure { step.unlock(token).await() }
+            .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
         server.verifyUnlock(token)
     }
 
@@ -879,7 +905,9 @@ internal class ConferenceStepTest {
             setResponseCode(404)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.muteGuests(token).await() }.isInstanceOf<NoSuchConferenceException>()
+        assertFailure { step.muteGuests(token).await() }
+            .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
         server.verifyMuteGuests(token)
     }
 
@@ -890,7 +918,9 @@ internal class ConferenceStepTest {
             setResponseCode(403)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.muteGuests(token).await() }.isInstanceOf<InvalidTokenException>()
+        assertFailure { step.muteGuests(token).await() }
+            .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
         server.verifyMuteGuests(token)
     }
 
@@ -928,7 +958,9 @@ internal class ConferenceStepTest {
             setResponseCode(404)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.unmuteGuests(token).await() }.isInstanceOf<NoSuchConferenceException>()
+        assertFailure { step.unmuteGuests(token).await() }
+            .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
         server.verifyUnmuteGuests(token)
     }
 
@@ -939,7 +971,9 @@ internal class ConferenceStepTest {
             setResponseCode(403)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.unmuteGuests(token).await() }.isInstanceOf<InvalidTokenException>()
+        assertFailure { step.unmuteGuests(token).await() }
+            .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
         server.verifyUnmuteGuests(token)
     }
 
@@ -977,7 +1011,9 @@ internal class ConferenceStepTest {
             setResponseCode(404)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.disconnect(token).await() }.isInstanceOf<NoSuchConferenceException>()
+        assertFailure { step.disconnect(token).await() }
+            .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
         server.verifyDisconnect(token)
     }
 
@@ -988,7 +1024,9 @@ internal class ConferenceStepTest {
             setResponseCode(403)
             setBody(json.encodeToString(Box(message)))
         }
-        assertFailure { step.disconnect(token).await() }.isInstanceOf<InvalidTokenException>()
+        assertFailure { step.disconnect(token).await() }
+            .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
         server.verifyDisconnect(token)
     }
 

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/DtmfRequestTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/DtmfRequestTest.kt
@@ -15,10 +15,11 @@
  */
 package com.pexip.sdk.api.infinity
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
 import com.pexip.sdk.infinity.test.nextString
 import kotlin.random.Random
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 internal class DtmfRequestTest {
 
@@ -26,7 +27,7 @@ internal class DtmfRequestTest {
     fun `valid digits return a DtmfRequest`() {
         val digits = Random.nextDigits(100)
         val request = DtmfRequest(digits)
-        assertEquals(digits, request.digits)
+        assertThat(request::digits).isEqualTo(digits)
     }
 
     @Test(IllegalArgumentException::class)

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/NodeResolverTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/NodeResolverTest.kt
@@ -17,12 +17,15 @@
 
 package com.pexip.sdk.api.infinity
 
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.pexip.sdk.api.coroutines.await
+import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
 import java.net.URL
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertEquals
 
 @RunWith(Parameterized::class)
 internal class NodeResolverTest(private val host: String, private val url: String?) {
@@ -35,11 +38,8 @@ internal class NodeResolverTest(private val host: String, private val url: Strin
     }
 
     @Test
-    fun `onSuccess is called`() {
-        assertEquals(
-            expected = listOfNotNull(url?.let(::URL)),
-            actual = resolver.resolve(host).execute(),
-        )
+    fun `onSuccess is called`() = runTest {
+        assertThat(resolver.resolve(host).await()).isEqualTo(listOfNotNull(url?.let(::URL)))
     }
 
     companion object {


### PR DESCRIPTION
As a bonus, remove most uses of `kotlin.test.assertEquals` (and others)
in favor of `assertk.*`.
