### PR TITLE
ci: force snyk to use runtime classpath

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,25 +45,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/dokka/htmlMultiModule
 
-  snyk_test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: snyk/actions/setup@master
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '21'
-
-      - uses: gradle/actions/setup-gradle@v3
-        with:
-          cache-read-only: true
-
-      - run: snyk test --all-sub-projects --severity-threshold=high
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-          SNYK_CFG_ORG: ${{ secrets.SNYK_CFG_ORG }}
-
   snyk_monitor:
     runs-on: ubuntu-latest
     steps:
@@ -78,7 +59,7 @@ jobs:
         with:
           cache-read-only: true
 
-      - run: snyk monitor --all-sub-projects --remote-repo-url=$GITHUB_REPOSITORY
+      - run: snyk monitor --all-sub-projects --remote-repo-url=$GITHUB_REPOSITORY --target-reference='$(git branch --show-current)' --configuration-matching='^(jvm|.*[rR]elease)?[rR]untimeClasspath$'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_CFG_ORG: ${{ secrets.SNYK_CFG_ORG }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           cache-read-only: true
 
-      - run: snyk monitor --all-sub-projects --remote-repo-url=$GITHUB_REPOSITORY --target-reference='$(git branch --show-current)' --configuration-matching="^(jvm|.*[rR]elease)?[rR]untimeClasspath$"
+      - run: snyk-linux monitor --all-sub-projects --remote-repo-url=$GITHUB_REPOSITORY --target-reference='$(git branch --show-current)' --configuration-matching='^(jvm|.*[rR]elease)?[rR]untimeClasspath$'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_CFG_ORG: ${{ secrets.SNYK_CFG_ORG }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           cache-read-only: true
 
-      - run: snyk monitor --all-sub-projects --remote-repo-url=$GITHUB_REPOSITORY --target-reference='$(git branch --show-current)' --configuration-matching='^(jvm|.*[rR]elease)?[rR]untimeClasspath$'
+      - run: snyk monitor --all-sub-projects --remote-repo-url=$GITHUB_REPOSITORY --target-reference='$(git branch --show-current)' --configuration-matching="^(jvm|.*[rR]elease)?[rR]untimeClasspath$"
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_CFG_ORG: ${{ secrets.SNYK_CFG_ORG }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: '21'
 
       - uses: gradle/actions/setup-gradle@v3
-      - run: snyk test --all-sub-projects --severity-threshold=high --configuration-matching='^(jvm|.*[rR]elease)?[rR]untimeClasspath$'
+      - run: snyk test --all-sub-projects --severity-threshold=high --configuration-matching="^(jvm|.*[rR]elease)?[rR]untimeClasspath$"
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_CFG_ORG: ${{ secrets.SNYK_CFG_ORG }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: '21'
 
       - uses: gradle/actions/setup-gradle@v3
-      - run: snyk test --all-sub-projects --severity-threshold=high
+      - run: snyk test --all-sub-projects --severity-threshold=high --configuration-matching='^(jvm|.*[rR]elease)?[rR]untimeClasspath$'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_CFG_ORG: ${{ secrets.SNYK_CFG_ORG }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,7 @@ jobs:
           java-version: '21'
 
       - uses: gradle/actions/setup-gradle@v3
-      - run: snyk test --all-sub-projects --severity-threshold=high --configuration-matching="^(jvm|.*[rR]elease)?[rR]untimeClasspath$"
+      - run: snyk-linux test --all-sub-projects --severity-threshold=high --configuration-matching='^(jvm|.*[rR]elease)?[rR]untimeClasspath$'
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
           SNYK_CFG_ORG: ${{ secrets.SNYK_CFG_ORG }}


### PR DESCRIPTION
We're mostly interested in checking the what we include as a dependency
in the released artifacts, a bit less so when it comes to tooling.

Note the switch to `snyk-linux` instead of `snyk` - it appears that there's an `eval` call that strips the first `'` symbol from the regex, causing the command to fail. Invoking `snyk-linux` directly does the trick, but will cause an error if we were to migrate to a macOS runner.