### PR TITLE
feat(api,conference): respect parent_participant_uuid

### DIFF
--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -1322,8 +1322,8 @@ public final class com/pexip/sdk/api/infinity/RequestTokenRequest$Companion {
 
 public final class com/pexip/sdk/api/infinity/RequestTokenResponse : com/pexip/sdk/api/infinity/Token {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/RequestTokenResponse$Companion;
-	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZIJLjava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZIJLjava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZIJLjava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZIJLjava/lang/String;Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Lcom/pexip/sdk/api/infinity/ServiceType;
 	public final fun component11 ()Ljava/util/List;
@@ -1333,7 +1333,8 @@ public final class com/pexip/sdk/api/infinity/RequestTokenResponse : com/pexip/s
 	public final fun component15 ()I
 	public final fun component16-UwyO8pc ()J
 	public final fun component17 ()Ljava/lang/String;
-	public final fun component18 ()Z
+	public final fun component18-584TFCM ()Ljava/lang/String;
+	public final fun component19 ()Z
 	public final fun component2-UwyO8pc ()J
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4-UyOe1Tk ()Ljava/lang/String;
@@ -1342,8 +1343,8 @@ public final class com/pexip/sdk/api/infinity/RequestTokenResponse : com/pexip/s
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Z
-	public final fun copy-BR1ji4I (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZIJLjava/lang/String;Z)Lcom/pexip/sdk/api/infinity/RequestTokenResponse;
-	public static synthetic fun copy-BR1ji4I$default (Lcom/pexip/sdk/api/infinity/RequestTokenResponse;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZIJLjava/lang/String;ZILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/RequestTokenResponse;
+	public final fun copy-UvH8iHw (Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZIJLjava/lang/String;Ljava/lang/String;Z)Lcom/pexip/sdk/api/infinity/RequestTokenResponse;
+	public static synthetic fun copy-UvH8iHw$default (Lcom/pexip/sdk/api/infinity/RequestTokenResponse;Ljava/lang/String;JLjava/lang/String;Ljava/lang/String;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/VersionResponse;ZZZLcom/pexip/sdk/api/infinity/ServiceType;Ljava/util/List;Ljava/util/List;ZZIJLjava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/RequestTokenResponse;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAnalyticsEnabled ()Z
 	public final fun getCallTag ()Ljava/lang/String;
@@ -1355,6 +1356,7 @@ public final class com/pexip/sdk/api/infinity/RequestTokenResponse : com/pexip/s
 	public final fun getDirectMediaRequested ()Z
 	public fun getExpires-UwyO8pc ()J
 	public final fun getGuestsCanPresent ()Z
+	public final fun getParentParticipantId-584TFCM ()Ljava/lang/String;
 	public final fun getParticipantId-UyOe1Tk ()Ljava/lang/String;
 	public final fun getParticipantName ()Ljava/lang/String;
 	public final fun getServiceType ()Lcom/pexip/sdk/api/infinity/ServiceType;

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/RequestTokenResponse.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/RequestTokenResponse.kt
@@ -56,6 +56,8 @@ public data class RequestTokenResponse(
     val clientStatsUpdateInterval: Duration = Duration.INFINITE,
     @SerialName("call_tag")
     val callTag: String = "",
+    @SerialName("parent_participant_uuid")
+    val parentParticipantId: ParticipantId? = null,
     @Transient
     val directMediaRequested: Boolean = false,
 ) : Token

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
@@ -282,6 +282,7 @@ internal class ConferenceStepTest {
                     dataChannelId = Random.nextInt(-1, 65536),
                     clientStatsUpdateInterval = Random.nextDuration(),
                     callTag = request.callTag,
+                    parentParticipantId = Random.nextParticipantId(),
                 )
                 server.enqueue {
                     setResponseCode(200)

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
@@ -74,6 +74,7 @@ public class InfinityConference private constructor(
     )
     private val listeners = CopyOnWriteArraySet<ConferenceEventListener>()
     private val mutableConferenceEvent = MutableSharedFlow<ConferenceEvent>()
+    private val participantId = response.parentParticipantId ?: response.participantId
 
     override val name: String = response.conferenceName
 
@@ -87,7 +88,7 @@ public class InfinityConference private constructor(
     override val roster: Roster = RosterImpl(
         scope = scope,
         event = event,
-        participantId = response.participantId,
+        participantId = participantId,
         store = store,
         step = step,
     )
@@ -102,7 +103,7 @@ public class InfinityConference private constructor(
         scope = scope,
         event = event,
         store = store,
-        participantStep = step.participant(response.participantId),
+        participantStep = step.participant(participantId),
         directMedia = response.directMedia,
         iceServers = buildList(response.stun.size + response.turn.size) {
             this += response.stun.map { IceServer.Builder(it.url).build() }
@@ -124,14 +125,14 @@ public class InfinityConference private constructor(
         null -> MessengerImpl(
             scope = scope,
             event = event,
-            senderId = response.participantId,
+            senderId = participantId,
             senderName = response.participantName,
             store = store,
             step = step,
         )
         else -> DataChannelMessengerImpl(
             scope = scope,
-            senderId = response.participantId,
+            senderId = participantId,
             senderName = response.participantName,
             dataChannel = dataChannel,
         )


### PR DESCRIPTION
In certain situations a `RequestTokenResponse` may contain a
`parent_participant_uuid` field which is effectively the participant we'd
like to represent and make calls on behalf of.
