### PR TITLE
fix(conference): incorrect use of parentParticipantId

### DIFF
--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
@@ -74,7 +74,6 @@ public class InfinityConference private constructor(
     )
     private val listeners = CopyOnWriteArraySet<ConferenceEventListener>()
     private val mutableConferenceEvent = MutableSharedFlow<ConferenceEvent>()
-    private val participantId = response.parentParticipantId ?: response.participantId
 
     override val name: String = response.conferenceName
 
@@ -88,7 +87,8 @@ public class InfinityConference private constructor(
     override val roster: Roster = RosterImpl(
         scope = scope,
         event = event,
-        participantId = participantId,
+        participantId = response.participantId,
+        parentParticipantId = response.parentParticipantId,
         store = store,
         step = step,
     )
@@ -103,7 +103,7 @@ public class InfinityConference private constructor(
         scope = scope,
         event = event,
         store = store,
-        participantStep = step.participant(participantId),
+        participantStep = step.participant(response.participantId),
         directMedia = response.directMedia,
         iceServers = buildList(response.stun.size + response.turn.size) {
             this += response.stun.map { IceServer.Builder(it.url).build() }
@@ -125,14 +125,14 @@ public class InfinityConference private constructor(
         null -> MessengerImpl(
             scope = scope,
             event = event,
-            senderId = participantId,
+            senderId = response.participantId,
             senderName = response.participantName,
             store = store,
             step = step,
         )
         else -> DataChannelMessengerImpl(
             scope = scope,
-            senderId = participantId,
+            senderId = response.participantId,
             senderName = response.participantName,
             dataChannel = dataChannel,
         )

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
@@ -273,90 +273,18 @@ class RosterImplTest {
     }
 
     @Test
-    fun `unspotlight() returns if participantId does not exist`() = runTest {
-        val roster = RosterImpl()
-        roster.unspotlight(Random.nextParticipantId())
+    fun `unspotlight() returns if participantId does not exist`() {
+        table.forAll(::`unspotlight() returns if participantId does not exist`)
     }
 
     @Test
-    fun `unspotlight() throws UnspotlightException`() = runTest {
-        val participants = List(10) { Random.nextParticipant(it) }
-        val causes = participants.associate { it.id to Throwable() }
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
-                    assertThat(participantId, "participantId")
-                        .isIn(*participants.map(Participant::id).toTypedArray())
-                    return object : InfinityService.ParticipantStep {
-
-                        override fun spotlightOff(token: Token): Call<Boolean> {
-                            assertThat(token, "token").isEqualTo(store.token.value)
-                            return object : TestCall<Boolean> {
-
-                                override fun enqueue(callback: Callback<Boolean>) =
-                                    callback.onFailure(this, causes.getValue(participantId))
-                            }
-                        }
-                    }
-                }
-            },
-        )
-        roster.participants.test {
-            event.subscriptionCount.first { it > 0 }
-            assertThat(awaitItem(), "participants").isEmpty()
-            participants.forEachIndexed { index, participant ->
-                val response = participant.toParticipantResponse()
-                val e = ParticipantCreateEvent(response)
-                event.emit(e)
-                assertThat(awaitItem(), "participants")
-                    .index(index)
-                    .isEqualTo(participant)
-            }
-        }
-        participants.forEach {
-            assertFailure { roster.unspotlight(it.id) }
-                .isInstanceOf<UnspotlightException>()
-                .hasCause(causes.getValue(it.id))
-        }
+    fun `unspotlight() throws UnspotlightException`() {
+        table.forAll(::`unspotlight() throws UnspotlightException`)
     }
 
     @Test
-    fun `unspotlight() returns`() = runTest {
-        val participants = List(10) { Random.nextParticipant(it) }
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
-                    assertThat(participantId, "participantId")
-                        .isIn(*participants.map(Participant::id).toTypedArray())
-                    return object : InfinityService.ParticipantStep {
-
-                        override fun spotlightOff(token: Token): Call<Boolean> {
-                            assertThat(token, "token").isEqualTo(store.token.value)
-                            return object : TestCall<Boolean> {
-
-                                override fun enqueue(callback: Callback<Boolean>) =
-                                    callback.onSuccess(this, true)
-                            }
-                        }
-                    }
-                }
-            },
-        )
-        roster.participants.test {
-            event.subscriptionCount.first { it > 0 }
-            assertThat(awaitItem(), "participants").isEmpty()
-            participants.forEachIndexed { index, participant ->
-                val response = participant.toParticipantResponse()
-                val e = ParticipantCreateEvent(response)
-                event.emit(e)
-                assertThat(awaitItem(), "participants")
-                    .index(index)
-                    .isEqualTo(participant)
-            }
-        }
-        participants.forEach { roster.unspotlight(it.id) }
+    fun `unspotlight() returns`() {
+        table.forAll(::`unspotlight() returns`)
     }
 
     @Test
@@ -1998,6 +1926,125 @@ class RosterImplTest {
             }
         }
         participants.forEach { roster.spotlight(it.id) }
+    }
+
+    private fun `unspotlight() returns if participantId does not exist`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val roster = RosterImpl(participantId, parentParticipantId)
+        roster.unspotlight(Random.nextParticipantId())
+    }
+
+    private fun `unspotlight() throws UnspotlightException`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val participants = List(10) {
+            Random.nextParticipant(
+                index = it,
+                id = when (it) {
+                    0 -> parentParticipantId ?: participantId
+                    else -> Random.nextParticipantId()
+                },
+            )
+        }
+        val participantIds = buildSet {
+            add(participantId)
+            participants.forEach { add(it.id) }
+        }
+        val causes = participantIds.associateWith { Throwable() }
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
+                    assertThat(participantId, "participantId").isIn(*participantIds.toTypedArray())
+                    return object : InfinityService.ParticipantStep {
+
+                        override fun spotlightOff(token: Token): Call<Boolean> {
+                            assertThat(token, "token").isEqualTo(store.token.value)
+                            return object : TestCall<Boolean> {
+
+                                override fun enqueue(callback: Callback<Boolean>) =
+                                    callback.onFailure(this, causes.getValue(participantId))
+                            }
+                        }
+                    }
+                }
+            },
+        )
+        roster.participants.test {
+            event.subscriptionCount.first { it > 0 }
+            assertThat(awaitItem(), "participants").isEmpty()
+            participants.forEachIndexed { index, participant ->
+                val response = participant.toParticipantResponse()
+                val e = ParticipantCreateEvent(response)
+                event.emit(e)
+                assertThat(awaitItem(), "participants")
+                    .index(index)
+                    .isEqualTo(participant)
+            }
+        }
+        participants.forEach {
+            assertFailure { roster.unspotlight(it.id) }
+                .isInstanceOf<UnspotlightException>()
+                .hasCause(causes.getValue(it.id))
+        }
+    }
+
+    private fun `unspotlight() returns`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val participants = List(10) {
+            Random.nextParticipant(
+                index = it,
+                id = when (it) {
+                    0 -> parentParticipantId ?: participantId
+                    else -> Random.nextParticipantId()
+                },
+            )
+        }
+        val participantIds = buildSet {
+            add(participantId)
+            participants.forEach { add(it.id) }
+        }
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
+                    assertThat(participantId, "participantId").isIn(*participantIds.toTypedArray())
+                    return object : InfinityService.ParticipantStep {
+
+                        override fun spotlightOff(token: Token): Call<Boolean> {
+                            assertThat(token, "token").isEqualTo(store.token.value)
+                            return object : TestCall<Boolean> {
+
+                                override fun enqueue(callback: Callback<Boolean>) =
+                                    callback.onSuccess(this, true)
+                            }
+                        }
+                    }
+                }
+            },
+        )
+        roster.participants.test {
+            event.subscriptionCount.first { it > 0 }
+            assertThat(awaitItem(), "participants").isEmpty()
+            participants.forEachIndexed { index, participant ->
+                val response = participant.toParticipantResponse()
+                val e = ParticipantCreateEvent(response)
+                event.emit(e)
+                assertThat(awaitItem(), "participants")
+                    .index(index)
+                    .isEqualTo(participant)
+            }
+        }
+        participants.forEach { roster.unspotlight(it.id) }
     }
 
     private fun Random.nextParticipant(

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
@@ -353,42 +353,13 @@ class RosterImplTest {
     }
 
     @Test
-    fun `disconnectAll() throws DisconnectAllException`() = runTest {
-        val cause = Throwable()
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun disconnect(token: Token): Call<Boolean> {
-                    assertThat(token, "token").isEqualTo(store.token.value)
-                    return object : TestCall<Boolean> {
-
-                        override fun enqueue(callback: Callback<Boolean>) =
-                            callback.onFailure(this, cause)
-                    }
-                }
-            },
-        )
-        assertFailure { roster.disconnectAll() }
-            .isInstanceOf<DisconnectAllException>()
-            .hasCause(cause)
+    fun `disconnectAll() throws DisconnectAllException`() {
+        table.forAll(::`disconnectAll() throws DisconnectAllException`)
     }
 
     @Test
-    fun `disconnectAll() returns`() = runTest {
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun disconnect(token: Token): Call<Boolean> {
-                    assertThat(token, "token").isEqualTo(store.token.value)
-                    return object : TestCall<Boolean> {
-
-                        override fun enqueue(callback: Callback<Boolean>) =
-                            callback.onSuccess(this, true)
-                    }
-                }
-            },
-        )
-        roster.disconnectAll()
+    fun `disconnectAll() returns`() {
+        table.forAll(::`disconnectAll() returns`)
     }
 
     private fun `does not update the list until syncing is finished`(
@@ -2182,6 +2153,53 @@ class RosterImplTest {
             },
         )
         roster.unmuteAllGuests()
+    }
+
+    private fun `disconnectAll() throws DisconnectAllException`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val cause = Throwable()
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun disconnect(token: Token): Call<Boolean> {
+                    assertThat(token, "token").isEqualTo(store.token.value)
+                    return object : TestCall<Boolean> {
+
+                        override fun enqueue(callback: Callback<Boolean>) =
+                            callback.onFailure(this, cause)
+                    }
+                }
+            },
+        )
+        assertFailure { roster.disconnectAll() }
+            .isInstanceOf<DisconnectAllException>()
+            .hasCause(cause)
+    }
+
+    private fun `disconnectAll() returns`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun disconnect(token: Token): Call<Boolean> {
+                    assertThat(token, "token").isEqualTo(store.token.value)
+                    return object : TestCall<Boolean> {
+
+                        override fun enqueue(callback: Callback<Boolean>) =
+                            callback.onSuccess(this, true)
+                    }
+                }
+            },
+        )
+        roster.disconnectAll()
     }
 
     private fun Random.nextParticipant(

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
@@ -333,42 +333,13 @@ class RosterImplTest {
     }
 
     @Test
-    fun `muteAllGuests() throws MuteAllGuestsException`() = runTest {
-        val cause = Throwable()
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun muteGuests(token: Token): Call<Boolean> {
-                    assertThat(token, "token").isEqualTo(store.token.value)
-                    return object : TestCall<Boolean> {
-
-                        override fun enqueue(callback: Callback<Boolean>) =
-                            callback.onFailure(this, cause)
-                    }
-                }
-            },
-        )
-        assertFailure { roster.muteAllGuests() }
-            .isInstanceOf<MuteAllGuestsException>()
-            .hasCause(cause)
+    fun `muteAllGuests() throws MuteAllGuestsException`() {
+        table.forAll(::`muteAllGuests() throws MuteAllGuestsException`)
     }
 
     @Test
-    fun `muteAllGuests() returns`() = runTest {
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun muteGuests(token: Token): Call<Boolean> {
-                    assertThat(token, "token").isEqualTo(store.token.value)
-                    return object : TestCall<Boolean> {
-
-                        override fun enqueue(callback: Callback<Boolean>) =
-                            callback.onSuccess(this, true)
-                    }
-                }
-            },
-        )
-        roster.muteAllGuests()
+    fun `muteAllGuests() returns`() {
+        table.forAll(::`muteAllGuests() returns`)
     }
 
     @Test
@@ -2146,6 +2117,53 @@ class RosterImplTest {
             },
         )
         roster.unlock()
+    }
+
+    private fun `muteAllGuests() throws MuteAllGuestsException`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val cause = Throwable()
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun muteGuests(token: Token): Call<Boolean> {
+                    assertThat(token, "token").isEqualTo(store.token.value)
+                    return object : TestCall<Boolean> {
+
+                        override fun enqueue(callback: Callback<Boolean>) =
+                            callback.onFailure(this, cause)
+                    }
+                }
+            },
+        )
+        assertFailure { roster.muteAllGuests() }
+            .isInstanceOf<MuteAllGuestsException>()
+            .hasCause(cause)
+    }
+
+    private fun `muteAllGuests() returns`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun muteGuests(token: Token): Call<Boolean> {
+                    assertThat(token, "token").isEqualTo(store.token.value)
+                    return object : TestCall<Boolean> {
+
+                        override fun enqueue(callback: Callback<Boolean>) =
+                            callback.onSuccess(this, true)
+                    }
+                }
+            },
+        )
+        roster.muteAllGuests()
     }
 
     private fun Random.nextParticipant(

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
@@ -2260,8 +2260,8 @@ class RosterImplTest {
 
     @Suppress("TestFunctionName")
     private fun TestScope.RosterImpl(
-        participantId: ParticipantId = this@RosterImplTest.participantId,
-        parentParticipantId: ParticipantId? = null,
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
         step: InfinityService.ConferenceStep = object : InfinityService.ConferenceStep {
             override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep =
                 object : InfinityService.ParticipantStep {}

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
@@ -323,42 +323,13 @@ class RosterImplTest {
     }
 
     @Test
-    fun `unlock() throws UnlockException`() = runTest {
-        val cause = Throwable()
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun unlock(token: Token): Call<Boolean> {
-                    assertThat(token, "token").isEqualTo(store.token.value)
-                    return object : TestCall<Boolean> {
-
-                        override fun enqueue(callback: Callback<Boolean>) =
-                            callback.onFailure(this, cause)
-                    }
-                }
-            },
-        )
-        assertFailure { roster.unlock() }
-            .isInstanceOf<UnlockException>()
-            .hasCause(cause)
+    fun `unlock() throws UnlockException`() {
+        table.forAll(::`unlock() throws UnlockException`)
     }
 
     @Test
-    fun `unlock() returns`() = runTest {
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun unlock(token: Token): Call<Boolean> {
-                    assertThat(token, "token").isEqualTo(store.token.value)
-                    return object : TestCall<Boolean> {
-
-                        override fun enqueue(callback: Callback<Boolean>) =
-                            callback.onSuccess(this, true)
-                    }
-                }
-            },
-        )
-        roster.unlock()
+    fun `unlock() returns`() {
+        table.forAll(::`unlock() returns`)
     }
 
     @Test
@@ -2128,6 +2099,53 @@ class RosterImplTest {
             },
         )
         roster.lock()
+    }
+
+    private fun `unlock() throws UnlockException`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val cause = Throwable()
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun unlock(token: Token): Call<Boolean> {
+                    assertThat(token, "token").isEqualTo(store.token.value)
+                    return object : TestCall<Boolean> {
+
+                        override fun enqueue(callback: Callback<Boolean>) =
+                            callback.onFailure(this, cause)
+                    }
+                }
+            },
+        )
+        assertFailure { roster.unlock() }
+            .isInstanceOf<UnlockException>()
+            .hasCause(cause)
+    }
+
+    private fun `unlock() returns`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun unlock(token: Token): Call<Boolean> {
+                    assertThat(token, "token").isEqualTo(store.token.value)
+                    return object : TestCall<Boolean> {
+
+                        override fun enqueue(callback: Callback<Boolean>) =
+                            callback.onSuccess(this, true)
+                    }
+                }
+            },
+        )
+        roster.unlock()
     }
 
     private fun Random.nextParticipant(

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
@@ -313,42 +313,13 @@ class RosterImplTest {
     }
 
     @Test
-    fun `lock() throws LockException`() = runTest {
-        val cause = Throwable()
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun lock(token: Token): Call<Boolean> {
-                    assertThat(token, "token").isEqualTo(store.token.value)
-                    return object : TestCall<Boolean> {
-
-                        override fun enqueue(callback: Callback<Boolean>) =
-                            callback.onFailure(this, cause)
-                    }
-                }
-            },
-        )
-        assertFailure { roster.lock() }
-            .isInstanceOf<LockException>()
-            .hasCause(cause)
+    fun `lock() throws LockException`() {
+        table.forAll(::`lock() throws LockException`)
     }
 
     @Test
-    fun `lock() returns`() = runTest {
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun lock(token: Token): Call<Boolean> {
-                    assertThat(token, "token").isEqualTo(store.token.value)
-                    return object : TestCall<Boolean> {
-
-                        override fun enqueue(callback: Callback<Boolean>) =
-                            callback.onSuccess(this, true)
-                    }
-                }
-            },
-        )
-        roster.lock()
+    fun `lock() returns`() {
+        table.forAll(::`lock() returns`)
     }
 
     @Test
@@ -2110,6 +2081,53 @@ class RosterImplTest {
             },
         )
         roster.lowerAllHands()
+    }
+
+    private fun `lock() throws LockException`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val cause = Throwable()
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun lock(token: Token): Call<Boolean> {
+                    assertThat(token, "token").isEqualTo(store.token.value)
+                    return object : TestCall<Boolean> {
+
+                        override fun enqueue(callback: Callback<Boolean>) =
+                            callback.onFailure(this, cause)
+                    }
+                }
+            },
+        )
+        assertFailure { roster.lock() }
+            .isInstanceOf<LockException>()
+            .hasCause(cause)
+    }
+
+    private fun `lock() returns`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun lock(token: Token): Call<Boolean> {
+                    assertThat(token, "token").isEqualTo(store.token.value)
+                    return object : TestCall<Boolean> {
+
+                        override fun enqueue(callback: Callback<Boolean>) =
+                            callback.onSuccess(this, true)
+                    }
+                }
+            },
+        )
+        roster.lock()
     }
 
     private fun Random.nextParticipant(

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
@@ -513,10 +513,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val causes = participantIds.associateWith { Throwable() }
         val roster = RosterImpl(
             participantId = participantId,
@@ -563,10 +560,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val roster = RosterImpl(
             participantId = participantId,
             parentParticipantId = parentParticipantId,
@@ -616,10 +610,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val causes = participantIds.associateWith { Throwable() }
         val roster = RosterImpl(
             participantId = participantId,
@@ -666,10 +657,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val roster = RosterImpl(
             participantId = participantId,
             parentParticipantId = parentParticipantId,
@@ -719,10 +707,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val causes = participantIds.associateWith { Throwable() }
         val roster = RosterImpl(
             participantId = participantId,
@@ -769,10 +754,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val roster = RosterImpl(
             participantId = participantId,
             parentParticipantId = parentParticipantId,
@@ -814,10 +796,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val causes = participantIds.associateWith { Throwable() }
         val roster = RosterImpl(
             participantId = participantId,
@@ -865,10 +844,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val roster = RosterImpl(
             participantId = participantId,
             parentParticipantId = parentParticipantId,
@@ -911,10 +887,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val causes = participantIds.associateWith { Throwable() }
         val roster = RosterImpl(
             participantId = participantId,
@@ -962,10 +935,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val roster = RosterImpl(
             participantId = participantId,
             parentParticipantId = parentParticipantId,
@@ -1016,10 +986,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val causes = participantIds.associateWith { Throwable() }
         val roster = RosterImpl(
             participantId = participantId,
@@ -1066,10 +1033,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val roster = RosterImpl(
             participantId = participantId,
             parentParticipantId = parentParticipantId,
@@ -1119,10 +1083,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val causes = participantIds.associateWith { Throwable() }
         val roster = RosterImpl(
             participantId = participantId,
@@ -1169,10 +1130,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val roster = RosterImpl(
             participantId = participantId,
             parentParticipantId = parentParticipantId,
@@ -1222,10 +1180,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val causes = participantIds.associateWith { Throwable() }
         val roster = RosterImpl(
             participantId = participantId,
@@ -1272,10 +1227,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val roster = RosterImpl(
             participantId = participantId,
             parentParticipantId = parentParticipantId,
@@ -1325,10 +1277,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val causes = participantIds.associateWith { Throwable() }
         val roster = RosterImpl(
             participantId = participantId,
@@ -1375,10 +1324,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val roster = RosterImpl(
             participantId = participantId,
             parentParticipantId = parentParticipantId,
@@ -1428,10 +1374,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val causes = participantIds.associateWith { Throwable() }
         val roster = RosterImpl(
             participantId = participantId,
@@ -1478,10 +1421,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val roster = RosterImpl(
             participantId = participantId,
             parentParticipantId = parentParticipantId,
@@ -1531,10 +1471,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val causes = participantIds.associateWith { Throwable() }
         val roster = RosterImpl(
             participantId = participantId,
@@ -1581,10 +1518,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val roster = RosterImpl(
             participantId = participantId,
             parentParticipantId = parentParticipantId,
@@ -1634,10 +1568,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val causes = participantIds.associateWith { Throwable() }
         val roster = RosterImpl(
             participantId = participantId,
@@ -1684,10 +1615,7 @@ class RosterImplTest {
         parentParticipantId: ParticipantId?,
     ) = runTest {
         val participants = Random.nextParticipantList(participantId, parentParticipantId)
-        val participantIds = buildSet {
-            add(participantId)
-            participants.forEach { add(it.id) }
-        }
+        val participantIds = participants.toParticipantIdSet(participantId)
         val roster = RosterImpl(
             participantId = participantId,
             parentParticipantId = parentParticipantId,
@@ -2039,6 +1967,11 @@ class RosterImplTest {
             index = it,
             id = if (it == 0) parentParticipantId ?: participantId else nextParticipantId(),
         )
+    }
+
+    private fun List<Participant>.toParticipantIdSet(participantId: ParticipantId) = buildSet {
+        add(participantId)
+        for (participant in this@toParticipantIdSet) add(participant.id)
     }
 
     private fun Participant.toParticipantResponse() = ParticipantResponse(

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
@@ -71,6 +71,7 @@ import com.pexip.sdk.infinity.test.nextParticipantId
 import com.pexip.sdk.infinity.test.nextString
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
 import kotlin.properties.Delegates
@@ -97,13 +98,7 @@ class RosterImplTest {
 
     @Test
     fun `does not update the list until syncing is finished`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.participants.test {
             event.subscriptionCount.first { it > 0 }
             assertThat(awaitItem(), "participants").isEmpty()
@@ -122,13 +117,7 @@ class RosterImplTest {
 
     @Test
     fun `create, update, delete, stage correctly modify the list`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.participants.test {
             event.subscriptionCount.first { it > 0 }
             assertThat(awaitItem(), "participants").isEmpty()
@@ -163,13 +152,7 @@ class RosterImplTest {
 
     @Test
     fun `update without a matching create does not modify the list`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.participants.test {
             event.subscriptionCount.first { it > 0 }
             assertThat(awaitItem(), "participants").isEmpty()
@@ -184,13 +167,7 @@ class RosterImplTest {
 
     @Test
     fun `me produces the correct participant`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.me.test {
             event.subscriptionCount.first { it > 0 }
             assertThat(awaitItem(), "me").isNull()
@@ -211,13 +188,7 @@ class RosterImplTest {
 
     @Test
     fun `locked produces the correct lock state`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.locked.test {
             event.subscriptionCount.first { it > 0 }
             assertThat(awaitItem(), "locked").isFalse()
@@ -233,13 +204,7 @@ class RosterImplTest {
 
     @Test
     fun `allGuestsMuted produces the correct all guests muted state`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.allGuestsMuted.test {
             event.subscriptionCount.first { it > 0 }
             assertThat(awaitItem(), "guestsMuted").isFalse()
@@ -255,13 +220,7 @@ class RosterImplTest {
 
     @Test
     fun `raiseHand() returns if participantId does not exist`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.raiseHand(Random.nextParticipantId())
     }
 
@@ -270,10 +229,6 @@ class RosterImplTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val causes = participants.associate { it.id to Throwable() }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -316,10 +271,6 @@ class RosterImplTest {
     fun `raiseHand() returns`() = runTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -356,13 +307,7 @@ class RosterImplTest {
 
     @Test
     fun `admit() returns if participantId does not exist`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.disconnect(Random.nextParticipantId())
     }
 
@@ -371,10 +316,6 @@ class RosterImplTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val causes = participants.associate { it.id to Throwable() }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -417,10 +358,6 @@ class RosterImplTest {
     fun `admit() returns`() = runTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -457,13 +394,7 @@ class RosterImplTest {
 
     @Test
     fun `disconnect() returns if participantId does not exist`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.disconnect(Random.nextParticipantId())
     }
 
@@ -472,10 +403,6 @@ class RosterImplTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val causes = participants.associate { it.id to Throwable() }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -518,10 +445,6 @@ class RosterImplTest {
     fun `disconnect() returns`() = runTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -561,10 +484,6 @@ class RosterImplTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val causes = participants.associate { it.id to Throwable() }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -608,10 +527,6 @@ class RosterImplTest {
     fun `makeHost() returns`() = runTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -652,10 +567,6 @@ class RosterImplTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val causes = participants.associate { it.id to Throwable() }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -699,10 +610,6 @@ class RosterImplTest {
     fun `makeGuest() returns`() = runTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -740,13 +647,7 @@ class RosterImplTest {
 
     @Test
     fun `mute() returns if participantId does not exist`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.mute(Random.nextParticipantId())
     }
 
@@ -755,10 +656,6 @@ class RosterImplTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val causes = participants.associate { it.id to Throwable() }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -801,10 +698,6 @@ class RosterImplTest {
     fun `mute() returns`() = runTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -841,13 +734,7 @@ class RosterImplTest {
 
     @Test
     fun `unmute() returns if participantId does not exist`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.unmute(Random.nextParticipantId())
     }
 
@@ -856,10 +743,6 @@ class RosterImplTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val causes = participants.associate { it.id to Throwable() }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -902,10 +785,6 @@ class RosterImplTest {
     fun `unmute() returns`() = runTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -942,13 +821,7 @@ class RosterImplTest {
 
     @Test
     fun `muteVideo() returns if participantId does not exist`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.muteVideo(Random.nextParticipantId())
     }
 
@@ -957,10 +830,6 @@ class RosterImplTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val causes = participants.associate { it.id to Throwable() }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -1003,10 +872,6 @@ class RosterImplTest {
     fun `muteVideo() returns`() = runTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -1043,13 +908,7 @@ class RosterImplTest {
 
     @Test
     fun `unmuteVideo() returns if participantId does not exist`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.unmuteVideo(Random.nextParticipantId())
     }
 
@@ -1058,10 +917,6 @@ class RosterImplTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val causes = participants.associate { it.id to Throwable() }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -1104,10 +959,6 @@ class RosterImplTest {
     fun `unmuteVideo() returns`() = runTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -1144,13 +995,7 @@ class RosterImplTest {
 
     @Test
     fun `spotlight() returns if participantId does not exist`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.spotlight(Random.nextParticipantId())
     }
 
@@ -1159,10 +1004,6 @@ class RosterImplTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val causes = participants.associate { it.id to Throwable() }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -1205,10 +1046,6 @@ class RosterImplTest {
     fun `spotlight() returns`() = runTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -1245,13 +1082,7 @@ class RosterImplTest {
 
     @Test
     fun `unspotlight() returns if participantId does not exist`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.unspotlight(Random.nextParticipantId())
     }
 
@@ -1260,10 +1091,6 @@ class RosterImplTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val causes = participants.associate { it.id to Throwable() }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -1306,10 +1133,6 @@ class RosterImplTest {
     fun `unspotlight() returns`() = runTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -1346,13 +1169,7 @@ class RosterImplTest {
 
     @Test
     fun `lowerHand() returns if participantId does not exist`() = runTest {
-        val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
-            step = object : InfinityService.ConferenceStep {},
-        )
+        val roster = RosterImpl()
         roster.lowerHand(Random.nextParticipantId())
     }
 
@@ -1361,10 +1178,6 @@ class RosterImplTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val causes = participants.associate { it.id to Throwable() }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -1407,10 +1220,6 @@ class RosterImplTest {
     fun `lowerHand() returns`() = runTest {
         val participants = List(10) { Random.nextParticipant(it) }
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep {
@@ -1449,10 +1258,6 @@ class RosterImplTest {
     fun `lowerAllHands() throws LowerAllHandsException`() = runTest {
         val cause = Throwable()
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun clearAllBuzz(token: Token): Call<Boolean> {
@@ -1473,10 +1278,6 @@ class RosterImplTest {
     @Test
     fun `lowerAllHands() returns`() = runTest {
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun clearAllBuzz(token: Token): Call<Boolean> {
@@ -1496,10 +1297,6 @@ class RosterImplTest {
     fun `lock() throws LockException`() = runTest {
         val cause = Throwable()
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun lock(token: Token): Call<Boolean> {
@@ -1520,10 +1317,6 @@ class RosterImplTest {
     @Test
     fun `lock() returns`() = runTest {
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun lock(token: Token): Call<Boolean> {
@@ -1543,10 +1336,6 @@ class RosterImplTest {
     fun `unlock() throws UnlockException`() = runTest {
         val cause = Throwable()
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun unlock(token: Token): Call<Boolean> {
@@ -1567,10 +1356,6 @@ class RosterImplTest {
     @Test
     fun `unlock() returns`() = runTest {
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun unlock(token: Token): Call<Boolean> {
@@ -1590,10 +1375,6 @@ class RosterImplTest {
     fun `muteAllGuests() throws MuteAllGuestsException`() = runTest {
         val cause = Throwable()
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun muteGuests(token: Token): Call<Boolean> {
@@ -1614,10 +1395,6 @@ class RosterImplTest {
     @Test
     fun `muteAllGuests() returns`() = runTest {
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun muteGuests(token: Token): Call<Boolean> {
@@ -1637,10 +1414,6 @@ class RosterImplTest {
     fun `unmuteAllGuests() throws UnmuteAllGuestsException`() = runTest {
         val cause = Throwable()
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun unmuteGuests(token: Token): Call<Boolean> {
@@ -1661,10 +1434,6 @@ class RosterImplTest {
     @Test
     fun `unmuteAllGuests() returns`() = runTest {
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun unmuteGuests(token: Token): Call<Boolean> {
@@ -1684,10 +1453,6 @@ class RosterImplTest {
     fun `disconnectAll() throws DisconnectAllException`() = runTest {
         val cause = Throwable()
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun disconnect(token: Token): Call<Boolean> {
@@ -1708,10 +1473,6 @@ class RosterImplTest {
     @Test
     fun `disconnectAll() returns`() = runTest {
         val roster = RosterImpl(
-            scope = backgroundScope,
-            event = event,
-            participantId = participantId,
-            store = store,
             step = object : InfinityService.ConferenceStep {
 
                 override fun disconnect(token: Token): Call<Boolean> {
@@ -1781,5 +1542,19 @@ class RosterImplTest {
             ServiceType.UNKNOWN -> ApiServiceType.UNKNOWN
         },
         callTag = callTag,
+    )
+
+    @Suppress("TestFunctionName")
+    private fun TestScope.RosterImpl(
+        step: InfinityService.ConferenceStep = object : InfinityService.ConferenceStep {
+            override fun participant(participantId: ParticipantId): InfinityService.ParticipantStep =
+                object : InfinityService.ParticipantStep {}
+        },
+    ) = RosterImpl(
+        scope = backgroundScope,
+        event = event,
+        participantId = participantId,
+        store = store,
+        step = step,
     )
 }

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
@@ -343,42 +343,13 @@ class RosterImplTest {
     }
 
     @Test
-    fun `unmuteAllGuests() throws UnmuteAllGuestsException`() = runTest {
-        val cause = Throwable()
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun unmuteGuests(token: Token): Call<Boolean> {
-                    assertThat(token, "token").isEqualTo(store.token.value)
-                    return object : TestCall<Boolean> {
-
-                        override fun enqueue(callback: Callback<Boolean>) =
-                            callback.onFailure(this, cause)
-                    }
-                }
-            },
-        )
-        assertFailure { roster.unmuteAllGuests() }
-            .isInstanceOf<UnmuteAllGuestsException>()
-            .hasCause(cause)
+    fun `unmuteAllGuests() throws UnmuteAllGuestsException`() {
+        table.forAll(::`unmuteAllGuests() throws UnmuteAllGuestsException`)
     }
 
     @Test
-    fun `unmuteAllGuests() returns`() = runTest {
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun unmuteGuests(token: Token): Call<Boolean> {
-                    assertThat(token, "token").isEqualTo(store.token.value)
-                    return object : TestCall<Boolean> {
-
-                        override fun enqueue(callback: Callback<Boolean>) =
-                            callback.onSuccess(this, true)
-                    }
-                }
-            },
-        )
-        roster.unmuteAllGuests()
+    fun `unmuteAllGuests() returns`() {
+        table.forAll(::`unmuteAllGuests() returns`)
     }
 
     @Test
@@ -2164,6 +2135,53 @@ class RosterImplTest {
             },
         )
         roster.muteAllGuests()
+    }
+
+    private fun `unmuteAllGuests() throws UnmuteAllGuestsException`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val cause = Throwable()
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun unmuteGuests(token: Token): Call<Boolean> {
+                    assertThat(token, "token").isEqualTo(store.token.value)
+                    return object : TestCall<Boolean> {
+
+                        override fun enqueue(callback: Callback<Boolean>) =
+                            callback.onFailure(this, cause)
+                    }
+                }
+            },
+        )
+        assertFailure { roster.unmuteAllGuests() }
+            .isInstanceOf<UnmuteAllGuestsException>()
+            .hasCause(cause)
+    }
+
+    private fun `unmuteAllGuests() returns`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun unmuteGuests(token: Token): Call<Boolean> {
+                    assertThat(token, "token").isEqualTo(store.token.value)
+                    return object : TestCall<Boolean> {
+
+                        override fun enqueue(callback: Callback<Boolean>) =
+                            callback.onSuccess(this, true)
+                    }
+                }
+            },
+        )
+        roster.unmuteAllGuests()
     }
 
     private fun Random.nextParticipant(

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
@@ -303,42 +303,13 @@ class RosterImplTest {
     }
 
     @Test
-    fun `lowerAllHands() throws LowerAllHandsException`() = runTest {
-        val cause = Throwable()
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun clearAllBuzz(token: Token): Call<Boolean> {
-                    assertThat(token, "token").isEqualTo(store.token.value)
-                    return object : TestCall<Boolean> {
-
-                        override fun enqueue(callback: Callback<Boolean>) =
-                            callback.onFailure(this, cause)
-                    }
-                }
-            },
-        )
-        assertFailure { roster.lowerAllHands() }
-            .isInstanceOf<LowerAllHandsException>()
-            .hasCause(cause)
+    fun `lowerAllHands() throws LowerAllHandsException`() {
+        table.forAll(::`lowerAllHands() throws LowerAllHandsException`)
     }
 
     @Test
-    fun `lowerAllHands() returns`() = runTest {
-        val roster = RosterImpl(
-            step = object : InfinityService.ConferenceStep {
-
-                override fun clearAllBuzz(token: Token): Call<Boolean> {
-                    assertThat(token, "token").isEqualTo(store.token.value)
-                    return object : TestCall<Boolean> {
-
-                        override fun enqueue(callback: Callback<Boolean>) =
-                            callback.onSuccess(this, true)
-                    }
-                }
-            },
-        )
-        roster.lowerAllHands()
+    fun `lowerAllHands() returns`() {
+        table.forAll(::`lowerAllHands() returns`)
     }
 
     @Test
@@ -2092,6 +2063,53 @@ class RosterImplTest {
             }
         }
         participants.forEach { roster.lowerHand(it.id) }
+    }
+
+    private fun `lowerAllHands() throws LowerAllHandsException`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val cause = Throwable()
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun clearAllBuzz(token: Token): Call<Boolean> {
+                    assertThat(token, "token").isEqualTo(store.token.value)
+                    return object : TestCall<Boolean> {
+
+                        override fun enqueue(callback: Callback<Boolean>) =
+                            callback.onFailure(this, cause)
+                    }
+                }
+            },
+        )
+        assertFailure { roster.lowerAllHands() }
+            .isInstanceOf<LowerAllHandsException>()
+            .hasCause(cause)
+    }
+
+    private fun `lowerAllHands() returns`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val roster = RosterImpl(
+            participantId = participantId,
+            parentParticipantId = parentParticipantId,
+            step = object : InfinityService.ConferenceStep {
+
+                override fun clearAllBuzz(token: Token): Call<Boolean> {
+                    assertThat(token, "token").isEqualTo(store.token.value)
+                    return object : TestCall<Boolean> {
+
+                        override fun enqueue(callback: Callback<Boolean>) =
+                            callback.onSuccess(this, true)
+                    }
+                }
+            },
+        )
+        roster.lowerAllHands()
     }
 
     private fun Random.nextParticipant(

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
@@ -76,7 +76,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Instant
-import kotlin.properties.Delegates
 import kotlin.random.Random
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -90,12 +89,9 @@ class RosterImplTest {
     private lateinit var store: TokenStore
     private lateinit var table: Table2<ParticipantId, ParticipantId?>
 
-    private var participantId: ParticipantId by Delegates.notNull()
-
     @BeforeTest
     fun setUp() {
         event = MutableSharedFlow(extraBufferCapacity = 1)
-        participantId = Random.nextParticipantId()
         store = TokenStore(Random.nextToken())
         table = tableOf("participantId", "parentParticipantId")
             .row<ParticipantId, ParticipantId?>(Random.nextParticipantId(), null)
@@ -516,15 +512,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -574,15 +562,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -635,15 +615,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -693,15 +665,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -754,15 +718,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -812,15 +768,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -865,15 +813,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -924,15 +864,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -978,15 +910,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1037,15 +961,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1099,15 +1015,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1157,15 +1065,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1218,15 +1118,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1276,15 +1168,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1337,15 +1221,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1395,15 +1271,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1456,15 +1324,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1514,15 +1374,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1575,15 +1427,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1633,15 +1477,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1694,15 +1530,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1752,15 +1580,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1813,15 +1633,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -1871,15 +1683,7 @@ class RosterImplTest {
         participantId: ParticipantId,
         parentParticipantId: ParticipantId?,
     ) = runTest {
-        val participants = List(10) {
-            Random.nextParticipant(
-                index = it,
-                id = when (it) {
-                    0 -> parentParticipantId ?: participantId
-                    else -> Random.nextParticipantId()
-                },
-            )
-        }
+        val participants = Random.nextParticipantList(participantId, parentParticipantId)
         val participantIds = buildSet {
             add(participantId)
             participants.forEach { add(it.id) }
@@ -2204,7 +2008,7 @@ class RosterImplTest {
 
     private fun Random.nextParticipant(
         index: Int = 0,
-        id: ParticipantId = if (index == 0) participantId else nextParticipantId(),
+        id: ParticipantId = nextParticipantId(),
     ): Participant {
         val startTime = Instant.fromEpochSeconds(0) + nextInt(0, 100).seconds
         return Participant(
@@ -2224,6 +2028,16 @@ class RosterImplTest {
             transferSupported = nextBoolean(),
             disconnectSupported = nextBoolean(),
             callTag = nextString(),
+        )
+    }
+
+    private fun Random.nextParticipantList(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = List(10) {
+        nextParticipant(
+            index = it,
+            id = if (it == 0) parentParticipantId ?: participantId else nextParticipantId(),
         )
     }
 


### PR DESCRIPTION
The previous implementation ended up causing more issues and overall introduced several other bugs.

The main culprit was found when testing a call scenario where the participant had a role of `guest`. Under these circumstances, a child participanat token cannot perform any actions on the parent participant (even though they're effectively the same), resulting in most calls either failing with proper HTTP response or in some cases emitting 200 without modifying state.

This PR flips things a bit and make all calls via child participant with an appropriate token, but uses parent participant to identify _self_ in the roster. This is necessary since child participant does not participate in populating the roster, only their parent does.

To simplify things a bit we switched from lazily creating instances of `ParticipantStep` to pre-allocating them on `participant_create` event with a small indirection in the presence of parent participant.
