### PR TITLE
fix(conference): emit a fake LayoutEvent

### DIFF
--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Layout.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Layout.kt
@@ -22,8 +22,8 @@ import com.pexip.sdk.infinity.LayoutId
  *
  * @property layout a currently visible layout (may be absent from [layouts] in some cases)
  * @property layouts a set of all available layouts
- * @property requestedPrimaryScreenHostLayout a requested layout visible on primary screen for hosts, may be null in direct media call
- * @property requestedPrimaryScreenGuestLayout a requested layout visible on primary screen for guests, may be null in direct media call
+ * @property requestedPrimaryScreenHostLayout a requested layout visible on primary screen for hosts, may be null
+ * @property requestedPrimaryScreenGuestLayout a requested layout visible on primary screen for guests, may be null
  * @property overlayTextEnabled true if overlay text is enabled, false otherwise
  */
 public data class Layout(

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImpl.kt
@@ -42,6 +42,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.stateIn
@@ -60,7 +61,10 @@ internal class ThemeImpl(
         .stateIn(scope, SharingStarted.Eagerly, step.avatar(store.token.value))
 
     override val layout: StateFlow<Layout?> = combine(
-        flow = event.filterIsInstance<LayoutEvent>(),
+        flow = flow {
+            emit(LayoutEvent(LayoutId("")))
+            event.filterIsInstance<LayoutEvent>().collect(::emit)
+        },
         flow2 = step.availableLayouts(store),
         flow3 = step.layoutSvgs(store),
         transform = ::toLayout,

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImplTest.kt
@@ -21,6 +21,7 @@ import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.hasCause
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isNotNull
 import assertk.assertions.isNull
@@ -86,19 +87,6 @@ class ThemeImplTest {
     fun `emits the current avatar`() = runTest {
         fun pathToUrl(path: String) = "https://$path.com"
 
-        val response = generateSequence { Random.nextString() }
-            .take(10)
-            .associateWith {
-                SplashScreenResponse(
-                    background = BackgroundResponse(Random.nextString()),
-                    elements = List(10) {
-                        ElementResponse.Text(
-                            color = Random.nextLong(Long.MAX_VALUE),
-                            text = Random.nextString(),
-                        )
-                    },
-                )
-            }
         val step = object : InfinityService.ConferenceStep {
 
             override fun avatar(token: Token): String {
@@ -165,6 +153,16 @@ class ThemeImplTest {
         theme.layout.test {
             event.awaitSubscriptionCountAtLeast(2)
             assertThat(awaitItem(), "layout").isNull()
+            assertThat(awaitItem(), "layout")
+                .isNotNull()
+                .all {
+                    prop(Layout::layout).isEqualTo(LayoutId(""))
+                    prop(Layout::layouts).isEqualTo(layouts)
+                    prop(Layout::requestedPrimaryScreenHostLayout).isNull()
+                    prop(Layout::requestedPrimaryScreenGuestLayout).isNull()
+                    prop(Layout::overlayTextEnabled).isFalse()
+                    prop(Layout::layoutSvgs).isEqualTo(layoutSvgs)
+                }
             repeat(10) {
                 val e = LayoutEvent(
                     layout = layouts.random(),


### PR DESCRIPTION
Several versions of Infinity have a bug where `layout` event will not be
emitted under certain circumstances (e.g. joining using SIP Session ID,
API-only participant, etc.).

This workaround emits a fake `layout` event without much set. During
normal operation it will be followed by a real one, overriding the
values. For SIP Session ID flow it will let the `Theme` construct the
`Layout`, albeit in a limited fashion.
