### PR TITLE
feat(media): handle coroutines exceptions

### DIFF
--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/WebRtcMediaConnectionFactory.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/WebRtcMediaConnectionFactory.kt
@@ -119,10 +119,10 @@ public class WebRtcMediaConnectionFactory private constructor(
         val audioSource = factory.createAudioSource(MediaConstraints())
         val audioTrack = factory.createAudioTrack(createMediaTrackId(), audioSource)
         return WebRtcLocalAudioTrack(
-            applicationContext = applicationContext,
+            context = applicationContext,
             audioSource = audioSource,
             audioTrack = audioTrack,
-            context = CoroutineContext(),
+            coroutineContext = CoroutineContext(),
             signalingDispatcher = signalingDispatcher,
         )
     }
@@ -153,7 +153,7 @@ public class WebRtcMediaConnectionFactory private constructor(
             videoCapturer = videoCapturer,
             videoSource = videoSource,
             videoTrack = factory.createVideoTrack(createMediaTrackId(), videoSource),
-            context = CoroutineContext(),
+            coroutineContext = CoroutineContext(),
             signalingDispatcher = signalingDispatcher,
         )
     }
@@ -190,7 +190,7 @@ public class WebRtcMediaConnectionFactory private constructor(
             videoCapturer = videoCapturer,
             videoSource = videoSource,
             videoTrack = factory.createVideoTrack(createMediaTrackId(), videoSource),
-            context = CoroutineContext(),
+            coroutineContext = CoroutineContext(),
             signalingDispatcher = signalingDispatcher,
         )
     }
@@ -200,7 +200,7 @@ public class WebRtcMediaConnectionFactory private constructor(
         return WebRtcMediaConnection(
             factory = this,
             config = config,
-            context = CoroutineContext(),
+            coroutineContext = CoroutineContext(),
             signalingDispatcher = signalingDispatcher,
         )
     }

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/WebRtcMediaConnectionFactory.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/WebRtcMediaConnectionFactory.kt
@@ -200,7 +200,7 @@ public class WebRtcMediaConnectionFactory private constructor(
         return WebRtcMediaConnection(
             factory = this,
             config = config,
-            scope = CoroutineScope(),
+            context = SupervisorJob(job) + workerDispatcher,
             signalingDispatcher = signalingDispatcher,
         )
     }

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/WebRtcMediaConnectionFactory.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/WebRtcMediaConnectionFactory.kt
@@ -43,7 +43,6 @@ import com.pexip.sdk.media.webrtc.internal.WebRtcLocalVideoTrack
 import com.pexip.sdk.media.webrtc.internal.WebRtcMediaConnection
 import com.pexip.sdk.media.webrtc.internal.from
 import com.pexip.sdk.media.webrtc.internal.maybeExecute
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -72,6 +71,7 @@ import org.webrtc.audio.JavaAudioDeviceModule
 import org.webrtc.audio.JavaAudioDeviceModule.AudioRecordStateCallback
 import org.webrtc.audio.JavaAudioDeviceModule.AudioTrackStateCallback
 import java.util.UUID
+import kotlin.coroutines.CoroutineContext
 import kotlin.properties.Delegates
 
 public class WebRtcMediaConnectionFactory private constructor(
@@ -119,10 +119,10 @@ public class WebRtcMediaConnectionFactory private constructor(
         val audioSource = factory.createAudioSource(MediaConstraints())
         val audioTrack = factory.createAudioTrack(createMediaTrackId(), audioSource)
         return WebRtcLocalAudioTrack(
-            context = applicationContext,
+            applicationContext = applicationContext,
             audioSource = audioSource,
             audioTrack = audioTrack,
-            scope = CoroutineScope(),
+            context = CoroutineContext(),
             signalingDispatcher = signalingDispatcher,
         )
     }
@@ -153,7 +153,7 @@ public class WebRtcMediaConnectionFactory private constructor(
             videoCapturer = videoCapturer,
             videoSource = videoSource,
             videoTrack = factory.createVideoTrack(createMediaTrackId(), videoSource),
-            scope = CoroutineScope(),
+            context = CoroutineContext(),
             signalingDispatcher = signalingDispatcher,
         )
     }
@@ -190,7 +190,7 @@ public class WebRtcMediaConnectionFactory private constructor(
             videoCapturer = videoCapturer,
             videoSource = videoSource,
             videoTrack = factory.createVideoTrack(createMediaTrackId(), videoSource),
-            scope = CoroutineScope(),
+            context = CoroutineContext(),
             signalingDispatcher = signalingDispatcher,
         )
     }
@@ -200,7 +200,7 @@ public class WebRtcMediaConnectionFactory private constructor(
         return WebRtcMediaConnection(
             factory = this,
             config = config,
-            context = SupervisorJob(job) + workerDispatcher,
+            context = CoroutineContext(),
             signalingDispatcher = signalingDispatcher,
         )
     }
@@ -242,8 +242,7 @@ public class WebRtcMediaConnectionFactory private constructor(
 
     private fun createMediaTrackId() = UUID.randomUUID().toString()
 
-    private fun CoroutineScope(): CoroutineScope =
-        CoroutineScope(SupervisorJob(job) + workerDispatcher)
+    private fun CoroutineContext(): CoroutineContext = SupervisorJob(job) + workerDispatcher
 
     private fun checkNotDisposed() =
         check(job.isActive) { "WebRtcMediaConnectionFactory has been disposed!" }

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
@@ -39,19 +39,39 @@ internal class WebRtcCameraVideoTrack(
     private val videoCapturer: CameraVideoCapturer,
     videoSource: VideoSource,
     videoTrack: VideoTrack,
-    coroutineContext: CoroutineContext,
+    private val scope: CoroutineScope,
     signalingDispatcher: CoroutineDispatcher,
-    private val scope: CoroutineScope = CoroutineScope(coroutineContext),
 ) : CameraVideoTrack, WebRtcLocalVideoTrack(
     applicationContext = applicationContext,
     eglBase = eglBase,
-    coroutineContext = coroutineContext,
     scope = scope,
     videoCapturer = videoCapturer,
     videoSource = videoSource,
     videoTrack = videoTrack,
     signalingDispatcher = signalingDispatcher,
 ) {
+
+    internal constructor(
+        factory: CameraVideoTrackFactory,
+        applicationContext: Context,
+        eglBase: EglBase?,
+        deviceName: String,
+        videoCapturer: CameraVideoCapturer,
+        videoSource: VideoSource,
+        videoTrack: VideoTrack,
+        coroutineContext: CoroutineContext,
+        signalingDispatcher: CoroutineDispatcher,
+    ) : this(
+        factory = factory,
+        applicationContext = applicationContext,
+        eglBase = eglBase,
+        deviceName = deviceName,
+        videoCapturer = videoCapturer,
+        videoSource = videoSource,
+        videoTrack = videoTrack,
+        scope = CoroutineScope(coroutineContext),
+        signalingDispatcher = signalingDispatcher,
+    )
 
     override fun switchCamera(callback: CameraVideoTrack.SwitchCameraCallback) {
         scope.launch {

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
@@ -41,7 +41,7 @@ internal class WebRtcCameraVideoTrack(
     videoTrack: VideoTrack,
     private val scope: CoroutineScope,
     signalingDispatcher: CoroutineDispatcher,
-) : CameraVideoTrack, WebRtcLocalVideoTrack(
+) : WebRtcLocalVideoTrack(
     applicationContext = applicationContext,
     eglBase = eglBase,
     scope = scope,
@@ -49,9 +49,10 @@ internal class WebRtcCameraVideoTrack(
     videoSource = videoSource,
     videoTrack = videoTrack,
     signalingDispatcher = signalingDispatcher,
-) {
+),
+    CameraVideoTrack {
 
-    internal constructor(
+    constructor(
         factory: CameraVideoTrackFactory,
         applicationContext: Context,
         eglBase: EglBase?,

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
@@ -39,19 +39,19 @@ internal class WebRtcCameraVideoTrack(
     private val videoCapturer: CameraVideoCapturer,
     videoSource: VideoSource,
     videoTrack: VideoTrack,
-    context: CoroutineContext,
+    coroutineContext: CoroutineContext,
     signalingDispatcher: CoroutineDispatcher,
+    private val scope: CoroutineScope = CoroutineScope(coroutineContext),
 ) : CameraVideoTrack, WebRtcLocalVideoTrack(
     applicationContext = applicationContext,
     eglBase = eglBase,
+    coroutineContext = coroutineContext,
+    scope = scope,
     videoCapturer = videoCapturer,
     videoSource = videoSource,
     videoTrack = videoTrack,
-    context = context,
     signalingDispatcher = signalingDispatcher,
 ) {
-
-    private val scope = CoroutineScope(context)
 
     override fun switchCamera(callback: CameraVideoTrack.SwitchCameraCallback) {
         scope.launch {

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
@@ -39,18 +39,18 @@ internal class WebRtcCameraVideoTrack(
     private val videoCapturer: CameraVideoCapturer,
     videoSource: VideoSource,
     videoTrack: VideoTrack,
-    private val scope: CoroutineScope,
+    scope: CoroutineScope,
     signalingDispatcher: CoroutineDispatcher,
-) : WebRtcLocalVideoTrack(
-    applicationContext = applicationContext,
-    eglBase = eglBase,
-    scope = scope,
-    videoCapturer = videoCapturer,
-    videoSource = videoSource,
-    videoTrack = videoTrack,
-    signalingDispatcher = signalingDispatcher,
-),
-    CameraVideoTrack {
+) : CameraVideoTrack,
+    WebRtcLocalVideoTrack(
+        applicationContext = applicationContext,
+        eglBase = eglBase,
+        scope = scope,
+        videoCapturer = videoCapturer,
+        videoSource = videoSource,
+        videoTrack = videoTrack,
+        signalingDispatcher = signalingDispatcher,
+    ) {
 
     constructor(
         factory: CameraVideoTrackFactory,

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import org.webrtc.CameraVideoCapturer
 import org.webrtc.EglBase
 import org.webrtc.VideoSource
 import org.webrtc.VideoTrack
+import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.resumeWithException
 import kotlin.coroutines.suspendCoroutine
@@ -38,7 +39,7 @@ internal class WebRtcCameraVideoTrack(
     private val videoCapturer: CameraVideoCapturer,
     videoSource: VideoSource,
     videoTrack: VideoTrack,
-    scope: CoroutineScope,
+    context: CoroutineContext,
     signalingDispatcher: CoroutineDispatcher,
 ) : CameraVideoTrack, WebRtcLocalVideoTrack(
     applicationContext = applicationContext,
@@ -46,9 +47,11 @@ internal class WebRtcCameraVideoTrack(
     videoCapturer = videoCapturer,
     videoSource = videoSource,
     videoTrack = videoTrack,
-    scope = scope,
+    context = context,
     signalingDispatcher = signalingDispatcher,
 ) {
+
+    private val scope = CoroutineScope(context)
 
     override fun switchCamera(callback: CameraVideoTrack.SwitchCameraCallback) {
         scope.launch {

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
@@ -39,18 +39,18 @@ internal class WebRtcCameraVideoTrack(
     private val videoCapturer: CameraVideoCapturer,
     videoSource: VideoSource,
     videoTrack: VideoTrack,
-    scope: CoroutineScope,
+    private val scope: CoroutineScope,
     signalingDispatcher: CoroutineDispatcher,
-) : CameraVideoTrack,
-    WebRtcLocalVideoTrack(
-        applicationContext = applicationContext,
-        eglBase = eglBase,
-        scope = scope,
-        videoCapturer = videoCapturer,
-        videoSource = videoSource,
-        videoTrack = videoTrack,
-        signalingDispatcher = signalingDispatcher,
-    ) {
+) : WebRtcLocalVideoTrack(
+    applicationContext = applicationContext,
+    eglBase = eglBase,
+    scope = scope,
+    videoCapturer = videoCapturer,
+    videoSource = videoSource,
+    videoTrack = videoTrack,
+    signalingDispatcher = signalingDispatcher,
+),
+    CameraVideoTrack {
 
     constructor(
         factory: CameraVideoTrackFactory,

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcCameraVideoTrack.kt
@@ -39,7 +39,7 @@ internal class WebRtcCameraVideoTrack(
     private val videoCapturer: CameraVideoCapturer,
     videoSource: VideoSource,
     videoTrack: VideoTrack,
-    private val scope: CoroutineScope,
+    scope: CoroutineScope,
     signalingDispatcher: CoroutineDispatcher,
 ) : WebRtcLocalVideoTrack(
     applicationContext = applicationContext,

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,18 +33,21 @@ import kotlinx.coroutines.withContext
 import org.webrtc.AudioSource
 import org.webrtc.AudioTrack
 import java.util.concurrent.CopyOnWriteArraySet
+import kotlin.coroutines.CoroutineContext
 
 internal class WebRtcLocalAudioTrack(
-    context: Context,
+    applicationContext: Context,
     private val audioSource: AudioSource,
     internal val audioTrack: AudioTrack,
-    private val scope: CoroutineScope,
+    context: CoroutineContext,
     signalingDispatcher: CoroutineDispatcher,
 ) : LocalAudioTrack {
 
+    private val scope = CoroutineScope(context)
+
     private val listeners = CopyOnWriteArraySet<LocalMediaTrack.CapturingListener>()
     private val microphoneMuteObserver =
-        context.microphoneMuteObserverIn(scope + signalingDispatcher)
+        applicationContext.microphoneMuteObserverIn(scope + signalingDispatcher)
 
     override val capturing: Boolean
         get() = !microphoneMuteObserver.microphoneMute.value

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
@@ -36,18 +36,18 @@ import java.util.concurrent.CopyOnWriteArraySet
 import kotlin.coroutines.CoroutineContext
 
 internal class WebRtcLocalAudioTrack(
-    applicationContext: Context,
+    context: Context,
     private val audioSource: AudioSource,
     internal val audioTrack: AudioTrack,
-    context: CoroutineContext,
+    coroutineContext: CoroutineContext,
     signalingDispatcher: CoroutineDispatcher,
 ) : LocalAudioTrack {
 
-    private val scope = CoroutineScope(context)
+    private val scope = CoroutineScope(coroutineContext)
 
     private val listeners = CopyOnWriteArraySet<LocalMediaTrack.CapturingListener>()
     private val microphoneMuteObserver =
-        applicationContext.microphoneMuteObserverIn(scope + signalingDispatcher)
+        context.microphoneMuteObserverIn(scope + signalingDispatcher)
 
     override val capturing: Boolean
         get() = !microphoneMuteObserver.microphoneMute.value

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalAudioTrack.kt
@@ -39,11 +39,23 @@ internal class WebRtcLocalAudioTrack(
     context: Context,
     private val audioSource: AudioSource,
     internal val audioTrack: AudioTrack,
-    coroutineContext: CoroutineContext,
+    private val scope: CoroutineScope,
     signalingDispatcher: CoroutineDispatcher,
 ) : LocalAudioTrack {
 
-    private val scope = CoroutineScope(coroutineContext)
+    internal constructor(
+        context: Context,
+        audioSource: AudioSource,
+        audioTrack: AudioTrack,
+        coroutineContext: CoroutineContext,
+        signalingDispatcher: CoroutineDispatcher,
+    ) : this(
+        context = context,
+        audioSource = audioSource,
+        audioTrack = audioTrack,
+        scope = CoroutineScope(coroutineContext),
+        signalingDispatcher = signalingDispatcher,
+    )
 
     private val listeners = CopyOnWriteArraySet<LocalMediaTrack.CapturingListener>()
     private val microphoneMuteObserver =

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
@@ -45,11 +45,10 @@ internal open class WebRtcLocalVideoTrack(
     private val videoCapturer: VideoCapturer,
     private val videoSource: VideoSource,
     internal val videoTrack: org.webrtc.VideoTrack,
-    protected val context: CoroutineContext,
+    internal val coroutineContext: CoroutineContext,
+    private val scope: CoroutineScope = CoroutineScope(coroutineContext),
     protected val signalingDispatcher: CoroutineDispatcher,
-) : LocalVideoTrack, VideoTrack by WebRtcVideoTrack(videoTrack, context) {
-
-    private val scope = CoroutineScope(context)
+) : LocalVideoTrack, VideoTrack by WebRtcVideoTrack(videoTrack, scope) {
 
     private val capturingListeners = CopyOnWriteArraySet<LocalMediaTrack.CapturingListener>()
     private val textureHelper =

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
@@ -47,9 +47,10 @@ internal open class WebRtcLocalVideoTrack(
     internal val videoTrack: org.webrtc.VideoTrack,
     private val scope: CoroutineScope,
     protected val signalingDispatcher: CoroutineDispatcher,
-) : LocalVideoTrack, VideoTrack by WebRtcVideoTrack(videoTrack, scope) {
+) : LocalVideoTrack,
+    VideoTrack by WebRtcVideoTrack(videoTrack, scope) {
 
-    internal constructor(
+    constructor(
         applicationContext: Context,
         eglBase: EglBase?,
         videoCapturer: VideoCapturer,

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
@@ -37,6 +37,7 @@ import org.webrtc.VideoFrame
 import org.webrtc.VideoSource
 import java.util.concurrent.CopyOnWriteArraySet
 import java.util.concurrent.TimeUnit
+import kotlin.coroutines.CoroutineContext
 
 internal open class WebRtcLocalVideoTrack(
     applicationContext: Context,
@@ -44,9 +45,11 @@ internal open class WebRtcLocalVideoTrack(
     private val videoCapturer: VideoCapturer,
     private val videoSource: VideoSource,
     internal val videoTrack: org.webrtc.VideoTrack,
-    protected val scope: CoroutineScope,
+    protected val context: CoroutineContext,
     protected val signalingDispatcher: CoroutineDispatcher,
-) : LocalVideoTrack, VideoTrack by WebRtcVideoTrack(videoTrack, scope) {
+) : LocalVideoTrack, VideoTrack by WebRtcVideoTrack(videoTrack, context) {
+
+    private val scope = CoroutineScope(context)
 
     private val capturingListeners = CopyOnWriteArraySet<LocalMediaTrack.CapturingListener>()
     private val textureHelper =

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
@@ -45,10 +45,27 @@ internal open class WebRtcLocalVideoTrack(
     private val videoCapturer: VideoCapturer,
     private val videoSource: VideoSource,
     internal val videoTrack: org.webrtc.VideoTrack,
-    internal val coroutineContext: CoroutineContext,
-    private val scope: CoroutineScope = CoroutineScope(coroutineContext),
+    private val scope: CoroutineScope,
     protected val signalingDispatcher: CoroutineDispatcher,
 ) : LocalVideoTrack, VideoTrack by WebRtcVideoTrack(videoTrack, scope) {
+
+    internal constructor(
+        applicationContext: Context,
+        eglBase: EglBase?,
+        videoCapturer: VideoCapturer,
+        videoSource: VideoSource,
+        videoTrack: org.webrtc.VideoTrack,
+        coroutineContext: CoroutineContext,
+        signalingDispatcher: CoroutineDispatcher,
+    ) : this(
+        applicationContext = applicationContext,
+        eglBase = eglBase,
+        videoCapturer = videoCapturer,
+        videoSource = videoSource,
+        videoTrack = videoTrack,
+        scope = CoroutineScope(coroutineContext),
+        signalingDispatcher = signalingDispatcher,
+    )
 
     private val capturingListeners = CopyOnWriteArraySet<LocalMediaTrack.CapturingListener>()
     private val textureHelper =

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
@@ -45,7 +45,7 @@ internal open class WebRtcLocalVideoTrack(
     private val videoCapturer: VideoCapturer,
     private val videoSource: VideoSource,
     internal val videoTrack: org.webrtc.VideoTrack,
-    private val scope: CoroutineScope,
+    protected val scope: CoroutineScope,
     protected val signalingDispatcher: CoroutineDispatcher,
 ) : LocalVideoTrack,
     VideoTrack by WebRtcVideoTrack(videoTrack, scope) {

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcLocalVideoTrack.kt
@@ -45,7 +45,7 @@ internal open class WebRtcLocalVideoTrack(
     private val videoCapturer: VideoCapturer,
     private val videoSource: VideoSource,
     internal val videoTrack: org.webrtc.VideoTrack,
-    protected val scope: CoroutineScope,
+    private val scope: CoroutineScope,
     protected val signalingDispatcher: CoroutineDispatcher,
 ) : LocalVideoTrack,
     VideoTrack by WebRtcVideoTrack(videoTrack, scope) {

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
@@ -78,7 +78,7 @@ internal class WebRtcMediaConnection(
     private val signalingDispatcher: CoroutineDispatcher,
 ) : MediaConnection {
 
-    val handler = CoroutineExceptionHandler { _, t ->
+    private val handler = CoroutineExceptionHandler { _, t ->
         when (t) {
             is CancellationException -> throw t
             else -> {} // Do nothing

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
@@ -444,7 +444,7 @@ internal class WebRtcMediaConnection(
         key: RtpTransceiverKey,
         flow: MutableStateFlow<VideoTrack?>,
     ) = wrapper.getRemoteVideoTrack(key)
-        .map { track -> track?.let { WebRtcVideoTrack(it, this) } }
+        .map { track -> track?.let { WebRtcVideoTrack(it, this.coroutineContext) } }
         .onEach { flow.value = it }
         .onCompletion { flow.value = null }
         .launchIn(this)

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
@@ -74,7 +74,7 @@ import kotlin.coroutines.CoroutineContext
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class WebRtcMediaConnection(
     factory: WebRtcMediaConnectionFactory,
-    context: CoroutineContext,
+    coroutineContext: CoroutineContext,
     private val config: MediaConnectionConfig,
     private val signalingDispatcher: CoroutineDispatcher,
 ) : MediaConnection {
@@ -83,7 +83,7 @@ internal class WebRtcMediaConnection(
         Log.v("WebRtcMediaConnection", "Coroutine failed", t)
     }
 
-    private val scope = CoroutineScope(context + handler)
+    private val scope = CoroutineScope(coroutineContext + handler)
 
     private val mutex = Mutex()
     private var polite = false
@@ -444,7 +444,7 @@ internal class WebRtcMediaConnection(
         key: RtpTransceiverKey,
         flow: MutableStateFlow<VideoTrack?>,
     ) = wrapper.getRemoteVideoTrack(key)
-        .map { track -> track?.let { WebRtcVideoTrack(it, this.coroutineContext) } }
+        .map { track -> track?.let { WebRtcVideoTrack(it, this) } }
         .onEach { flow.value = it }
         .onCompletion { flow.value = null }
         .launchIn(this)

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
@@ -15,6 +15,7 @@
  */
 package com.pexip.sdk.media.webrtc.internal
 
+import android.util.Log
 import com.pexip.sdk.media.Bitrate
 import com.pexip.sdk.media.Bitrate.Companion.bps
 import com.pexip.sdk.media.CandidateSignalingEvent
@@ -79,10 +80,7 @@ internal class WebRtcMediaConnection(
 ) : MediaConnection {
 
     private val handler = CoroutineExceptionHandler { _, t ->
-        when (t) {
-            is CancellationException -> throw t
-            else -> {} // Do nothing
-        }
+        Log.v("WebRtcMediaConnection", "Coroutine failed", t)
     }
 
     private val scope = CoroutineScope(context + handler)

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcVideoTrack.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Pexip AS
+ * Copyright 2022-2023 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcVideoTrack.kt
@@ -20,14 +20,11 @@ import com.pexip.sdk.media.VideoTrack
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.webrtc.VideoSink
-import kotlin.coroutines.CoroutineContext
 
 internal class WebRtcVideoTrack(
     private val videoTrack: org.webrtc.VideoTrack,
-    context: CoroutineContext,
+    private val scope: CoroutineScope,
 ) : VideoTrack {
-
-    private val scope = CoroutineScope(context)
 
     override fun addRenderer(renderer: Renderer) {
         require(renderer is VideoSink) { "renderer must be an instance of VideoSink." }

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcVideoTrack.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcVideoTrack.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,11 +20,14 @@ import com.pexip.sdk.media.VideoTrack
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.webrtc.VideoSink
+import kotlin.coroutines.CoroutineContext
 
 internal class WebRtcVideoTrack(
     private val videoTrack: org.webrtc.VideoTrack,
-    private val scope: CoroutineScope,
+    context: CoroutineContext,
 ) : VideoTrack {
+
+    private val scope = CoroutineScope(context)
 
     override fun addRenderer(renderer: Renderer) {
         require(renderer is VideoSink) { "renderer must be an instance of VideoSink." }


### PR DESCRIPTION
This stops the exceptions from API calls during a media connection propagating uncontrollably to the clients and crashing them