### PR TITLE
feat: bump targetSdk to 34

### DIFF
--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/AndroidApplicationPlugin.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/AndroidApplicationPlugin.kt
@@ -32,11 +32,11 @@ class AndroidApplicationPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         pluginManager.apply("com.android.application")
         configure<ApplicationExtension> {
-            compileSdk = Android.compileSdk
+            compileSdk = Android.COMPILE_SDK
             defaultConfig {
-                minSdk = Android.minSdk
-                targetSdk = Android.targetSdk
-                testInstrumentationRunner = Android.testInstrumentationRunner
+                minSdk = Android.MIN_SDK
+                targetSdk = Android.TARGET_SDK
+                testInstrumentationRunner = Android.TEST_INSTRUMENTATION_RUNNER
             }
             buildFeatures {
                 buildConfig = true

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/AndroidLibraryPlugin.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/AndroidLibraryPlugin.kt
@@ -32,10 +32,10 @@ class AndroidLibraryPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         pluginManager.apply("com.android.library")
         configure<LibraryExtension> {
-            compileSdk = Android.compileSdk
+            compileSdk = Android.COMPILE_SDK
             defaultConfig {
-                minSdk = Android.minSdk
-                testInstrumentationRunner = Android.testInstrumentationRunner
+                minSdk = Android.MIN_SDK
+                testInstrumentationRunner = Android.TEST_INSTRUMENTATION_RUNNER
             }
             buildFeatures {
                 buildConfig = false

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/internal/Android.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/internal/Android.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Pexip AS
+ * Copyright 2023-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,11 +19,11 @@ import org.gradle.api.JavaVersion
 
 internal object Android {
 
-    const val minSdk = 21
-    const val targetSdk = 33
-    const val compileSdk = 34
+    const val MIN_SDK = 21
+    const val TARGET_SDK = 34
+    const val COMPILE_SDK = 34
 
-    const val testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    const val TEST_INSTRUMENTATION_RUNNER = "androidx.test.runner.AndroidJUnitRunner"
 
     val sourceCompatibility = JavaVersion.VERSION_11
     val targetCompatibility = JavaVersion.VERSION_11

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -1,7 +1,16 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-feature
+        android:name="android.hardware.camera"
+        android:required="false" />
+
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CAMERA" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MICROPHONE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PROJECTION" />
 
     <application
         android:name=".SampleApplication"
@@ -28,7 +37,11 @@
 
         <service
             android:name=".conference.ConferenceService"
-            android:foregroundServiceType="camera|mediaProjection" />
+            android:foregroundServiceType="camera|microphone" />
+
+        <service
+            android:name=".conference.ConferenceMediaProjectionService"
+            android:foregroundServiceType="mediaProjection" />
 
         <provider
             android:name="androidx.startup.InitializationProvider"

--- a/sample/src/main/kotlin/com/pexip/sdk/sample/conference/ConferenceMediaProjectionService.kt
+++ b/sample/src/main/kotlin/com/pexip/sdk/sample/conference/ConferenceMediaProjectionService.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Pexip AS
+ * Copyright 2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
 @AndroidEntryPoint
-class ConferenceService : Service() {
+class ConferenceMediaProjectionService : Service() {
 
     @Inject
     lateinit var manager: NotificationManagerCompat
@@ -46,7 +46,7 @@ class ConferenceService : Service() {
         manager.createNotificationChannel(notificationChannel)
         val notification = NotificationCompat.Builder(this, notificationChannel.id)
             .setOngoing(true)
-            .setContentTitle(getString(R.string.conference_notification_content_title))
+            .setContentTitle(getString(R.string.conference_media_projection_notification_content_title))
             .setSmallIcon(R.drawable.ic_launcher_foreground)
             .build()
         val serviceType =
@@ -63,7 +63,7 @@ class ConferenceService : Service() {
 
     private companion object {
 
-        const val NOTIFICATION_ID = 1
+        const val NOTIFICATION_ID = 2
         const val NOTIFICATION_CHANNEL_IMPORTANCE = NotificationManagerCompat.IMPORTANCE_DEFAULT
     }
 }

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -6,6 +6,7 @@
     <string name="conference_notification_channel_id" translatable="false">conference</string>
     <string name="conference_notification_channel_name">Conference</string>
     <string name="conference_notification_content_title">Conference</string>
+    <string name="conference_media_projection_notification_content_title">Sharing screen</string>
     <!-- PERMISSIONS -->
     <string name="permissions_title">Grant permissions</string>
     <string name="permissions_description">Granting permission in the next screen will make sure other participants are able to see and hear you if you’ve enabled your camera and microphone</string>


### PR DESCRIPTION
`Service.startForeground()` doesn't seem to allow passing multiple
flags in `foregroundServiceType`, so instead a special
`ConferenceMediaProjectionService` is introduced to notify when the
screen is being shared.
