### PR TITLE
feat(api): add client_mute, client_unmute and is_client_muted

### DIFF
--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -617,6 +617,8 @@ public abstract interface class com/pexip/sdk/api/infinity/InfinityService$Parti
 	public fun call-ZWg4wSc (Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/InfinityService$CallStep;
 	public fun calls (Lcom/pexip/sdk/api/infinity/CallsRequest;Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun clearBuzz (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
+	public fun clientMute (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
+	public fun clientUnmute (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun disconnect (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun dtmf (Lcom/pexip/sdk/api/infinity/DtmfRequest;Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun getConferenceStep ()Lcom/pexip/sdk/api/infinity/InfinityService$ConferenceStep;
@@ -953,8 +955,8 @@ public final class com/pexip/sdk/api/infinity/ParticipantDeleteEvent$Companion {
 
 public final class com/pexip/sdk/api/infinity/ParticipantResponse {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/ParticipantResponse$Companion;
-	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/String;ZZZZZZLcom/pexip/sdk/infinity/Role;Lcom/pexip/sdk/infinity/ServiceType;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/String;ZZZZZZLcom/pexip/sdk/infinity/Role;Lcom/pexip/sdk/infinity/ServiceType;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/String;ZZZZZZLcom/pexip/sdk/infinity/Role;Lcom/pexip/sdk/infinity/ServiceType;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/String;ZZZZZZLcom/pexip/sdk/infinity/Role;Lcom/pexip/sdk/infinity/ServiceType;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-UyOe1Tk ()Ljava/lang/String;
 	public final fun component10 ()Z
 	public final fun component11 ()Lcom/pexip/sdk/infinity/Role;
@@ -962,6 +964,7 @@ public final class com/pexip/sdk/api/infinity/ParticipantResponse {
 	public final fun component13 ()Lkotlinx/datetime/Instant;
 	public final fun component14 ()Lkotlinx/datetime/Instant;
 	public final fun component15 ()Ljava/lang/String;
+	public final fun component16 ()Z
 	public final fun component2 ()Lkotlinx/datetime/Instant;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -970,12 +973,13 @@ public final class com/pexip/sdk/api/infinity/ParticipantResponse {
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Z
-	public final fun copy-r1mxKX4 (Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/String;ZZZZZZLcom/pexip/sdk/infinity/Role;Lcom/pexip/sdk/infinity/ServiceType;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/ParticipantResponse;
-	public static synthetic fun copy-r1mxKX4$default (Lcom/pexip/sdk/api/infinity/ParticipantResponse;Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/String;ZZZZZZLcom/pexip/sdk/infinity/Role;Lcom/pexip/sdk/infinity/ServiceType;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ljava/lang/String;ILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/ParticipantResponse;
+	public final fun copy-uQylcWo (Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/String;ZZZZZZLcom/pexip/sdk/infinity/Role;Lcom/pexip/sdk/infinity/ServiceType;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ljava/lang/String;Z)Lcom/pexip/sdk/api/infinity/ParticipantResponse;
+	public static synthetic fun copy-uQylcWo$default (Lcom/pexip/sdk/api/infinity/ParticipantResponse;Ljava/lang/String;Lkotlinx/datetime/Instant;Ljava/lang/String;Ljava/lang/String;ZZZZZZLcom/pexip/sdk/infinity/Role;Lcom/pexip/sdk/infinity/ServiceType;Lkotlinx/datetime/Instant;Lkotlinx/datetime/Instant;Ljava/lang/String;ZILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/ParticipantResponse;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAudioMuted ()Z
 	public final fun getBuzzTime ()Lkotlinx/datetime/Instant;
 	public final fun getCallTag ()Ljava/lang/String;
+	public final fun getClientAudioMuted ()Z
 	public final fun getDisconnectSupported ()Z
 	public final fun getDisplayName ()Ljava/lang/String;
 	public final fun getId-UyOe1Tk ()Ljava/lang/String;

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
@@ -470,6 +470,28 @@ public interface InfinityService {
         public fun unmute(token: Token): Call<Unit> = throw NotImplementedError()
 
         /**
+         * Signals that the participant has muted themselves.
+         *
+         * Only applicable to self.
+         *
+         * See [documentation](https://docs.pexip.com/api_client/api_rest.htm#client_mute).
+         *
+         * @param token a valid token
+         */
+        public fun clientMute(token: Token): Call<Unit> = throw NotImplementedError()
+
+        /**
+         * Signals that the participant has unmuted themselves.
+         *
+         * Only applicable to self.
+         *
+         * See [documentation](https://docs.pexip.com/api_client/api_rest.htm#client_unmute).
+         *
+         * @param token a valid token
+         */
+        public fun clientUnmute(token: Token): Call<Unit> = throw NotImplementedError()
+
+        /**
          * Requests to mute participant's video.
          *
          * See [documentation](https://docs.pexip.com/api_client/api_rest.htm#videomute).

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/ParticipantResponse.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/ParticipantResponse.kt
@@ -57,4 +57,6 @@ public data class ParticipantResponse(
     val spotlightTime: Instant? = null,
     @SerialName("call_tag")
     val callTag: String = "",
+    @SerialName("is_client_muted")
+    val clientAudioMuted: Boolean = audioMuted,
 )

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ParticipantStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ParticipantStepImpl.kt
@@ -97,6 +97,34 @@ internal class ParticipantStepImpl(
         mapper = ::parseMuteUnmute,
     )
 
+    override fun clientMute(token: Token): Call<Unit> = RealCall(
+        client = client,
+        request = Request.Builder()
+            .post(EMPTY_REQUEST)
+            .url(url) {
+                conference(conferenceAlias)
+                participant(participantId)
+                addPathSegment("client_mute")
+            }
+            .token(token)
+            .build(),
+        mapper = ::parseClientMuteClientUnmute,
+    )
+
+    override fun clientUnmute(token: Token): Call<Unit> = RealCall(
+        client = client,
+        request = Request.Builder()
+            .post(EMPTY_REQUEST)
+            .url(url) {
+                conference(conferenceAlias)
+                participant(participantId)
+                addPathSegment("client_unmute")
+            }
+            .token(token)
+            .build(),
+        mapper = ::parseClientMuteClientUnmute,
+    )
+
     override fun videoMuted(token: Token): Call<Unit> = RealCall(
         client = client,
         request = Request.Builder()
@@ -285,6 +313,13 @@ internal class ParticipantStepImpl(
     override fun call(callId: CallId): InfinityService.CallStep = CallStepImpl(this, callId)
 
     private fun parseMuteUnmute(response: Response) = when (response.code) {
+        200 -> Unit
+        403 -> response.parse403()
+        404 -> response.parse404()
+        else -> throw IllegalStateException()
+    }
+
+    private fun parseClientMuteClientUnmute(response: Response) = when (response.code) {
         200 -> Unit
         403 -> response.parse403()
         404 -> response.parse404()

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ParticipantStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ParticipantStepTest.kt
@@ -281,6 +281,100 @@ internal class ParticipantStepTest {
     }
 
     @Test
+    fun `clientMute throws IllegalStateException`() = runTest {
+        server.enqueue { setResponseCode(500) }
+        assertFailure { step.clientMute(token).await() }.isInstanceOf<IllegalStateException>()
+        server.verifyClientMute(token)
+    }
+
+    @Test
+    fun `clientMute throws NoSuchNodeException`() = runTest {
+        server.enqueue { setResponseCode(404) }
+        assertFailure { step.clientMute(token).await() }.isInstanceOf<NoSuchNodeException>()
+        server.verifyClientMute(token)
+    }
+
+    @Test
+    fun `clientMute throws NoSuchConferenceException`() = runTest {
+        val message = "Neither conference nor gateway found"
+        server.enqueue {
+            setResponseCode(404)
+            setBody(json.encodeToString(Box(message)))
+        }
+        assertFailure { step.clientMute(token).await() }
+            .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
+        server.verifyClientMute(token)
+    }
+
+    @Test
+    fun `clientMute throws InvalidTokenException`() = runTest {
+        val message = "Invalid token"
+        server.enqueue {
+            setResponseCode(403)
+            setBody(json.encodeToString(Box(message)))
+        }
+        assertFailure { step.clientMute(token).await() }
+            .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
+        server.verifyClientMute(token)
+    }
+
+    @Test
+    fun `clientMute returns`() = runTest {
+        server.enqueue { setResponseCode(200) }
+        step.clientMute(token).await()
+        server.verifyClientMute(token)
+    }
+
+    @Test
+    fun `clientUnmute throws IllegalStateException`() = runTest {
+        server.enqueue { setResponseCode(500) }
+        assertFailure { step.clientUnmute(token).await() }.isInstanceOf<IllegalStateException>()
+        server.verifyClientUnmute(token)
+    }
+
+    @Test
+    fun `clientUnmute throws NoSuchNodeException`() = runTest {
+        server.enqueue { setResponseCode(404) }
+        assertFailure { step.clientUnmute(token).await() }.isInstanceOf<NoSuchNodeException>()
+        server.verifyClientUnmute(token)
+    }
+
+    @Test
+    fun `clientUnmute throws NoSuchConferenceException`() = runTest {
+        val message = "Neither conference nor gateway found"
+        server.enqueue {
+            setResponseCode(404)
+            setBody(json.encodeToString(Box(message)))
+        }
+        assertFailure { step.clientUnmute(token).await() }
+            .isInstanceOf<NoSuchConferenceException>()
+            .hasMessage(message)
+        server.verifyClientUnmute(token)
+    }
+
+    @Test
+    fun `clientUnmute throws InvalidTokenException`() = runTest {
+        val message = "Invalid token"
+        server.enqueue {
+            setResponseCode(403)
+            setBody(json.encodeToString(Box(message)))
+        }
+        assertFailure { step.clientUnmute(token).await() }
+            .isInstanceOf<InvalidTokenException>()
+            .hasMessage(message)
+        server.verifyClientUnmute(token)
+    }
+
+    @Test
+    fun `clientUnmute returns`() = runTest {
+        server.enqueue { setResponseCode(200) }
+        step.clientUnmute(token).await()
+        server.verifyClientUnmute(token)
+    }
+
+    @Test
     fun `videoMuted throws IllegalStateException`() = runTest {
         server.enqueue { setResponseCode(500) }
         assertFailure { step.videoMuted(token).await() }.isInstanceOf<IllegalStateException>()
@@ -952,6 +1046,32 @@ internal class ParticipantStepTest {
             addPathSegment("participants")
             addPathSegment(participantId)
             addPathSegment("unmute")
+        }
+        assertToken(token)
+        assertPostEmptyBody()
+    }
+
+    private fun MockWebServer.verifyClientMute(token: Token) = takeRequest {
+        assertRequestUrl(node) {
+            addPathSegments("api/client/v2")
+            addPathSegment("conferences")
+            addPathSegment(conferenceAlias)
+            addPathSegment("participants")
+            addPathSegment(participantId)
+            addPathSegment("client_mute")
+        }
+        assertToken(token)
+        assertPostEmptyBody()
+    }
+
+    private fun MockWebServer.verifyClientUnmute(token: Token) = takeRequest {
+        assertRequestUrl(node) {
+            addPathSegments("api/client/v2")
+            addPathSegment("conferences")
+            addPathSegment(conferenceAlias)
+            addPathSegment("participants")
+            addPathSegment(participantId)
+            addPathSegment("client_unmute")
         }
         assertToken(token)
         assertPostEmptyBody()

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/EventTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/EventTest.kt
@@ -283,6 +283,7 @@ internal class EventTest {
                         role = Role.HOST,
                         serviceType = ServiceType.GATEWAY,
                         callTag = "dd806491-eecc-42fc-accb-86a99448fc17",
+                        clientAudioMuted = true,
                     ),
                 ),
             )

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/EventTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/EventTest.kt
@@ -227,6 +227,7 @@ internal class EventTest {
                         role = Role.GUEST,
                         serviceType = ServiceType.CONFERENCE,
                         callTag = "dd806491-eecc-42fc-accb-86a99448fc17",
+                        clientAudioMuted = false,
                     ),
                 ),
             )
@@ -251,6 +252,7 @@ internal class EventTest {
                         role = Role.UNKNOWN,
                         serviceType = ServiceType.CONFERENCE,
                         callTag = "dd806491-eecc-42fc-accb-86a99448fc17",
+                        clientAudioMuted = false,
                     ),
                 ),
             )

--- a/sdk-api/src/test/resources/participant_create.json
+++ b/sdk-api/src/test/resources/participant_create.json
@@ -34,5 +34,6 @@
   "is_main_video_dropped_out": false,
   "needs_presentation_in_mix": false,
   "show_live_captions": false,
-  "is_idp_authenticated": false
+  "is_idp_authenticated": false,
+  "is_client_muted": false
 }

--- a/sdk-api/src/test/resources/participant_create_unknown.json
+++ b/sdk-api/src/test/resources/participant_create_unknown.json
@@ -34,5 +34,6 @@
   "is_main_video_dropped_out": false,
   "needs_presentation_in_mix": false,
   "show_live_captions": false,
-  "is_idp_authenticated": false
+  "is_idp_authenticated": false,
+  "is_client_muted": false
 }

--- a/sdk-api/src/test/resources/participant_update.json
+++ b/sdk-api/src/test/resources/participant_update.json
@@ -34,5 +34,6 @@
   "is_main_video_dropped_out": false,
   "needs_presentation_in_mix": false,
   "show_live_captions": false,
-  "is_idp_authenticated": false
+  "is_idp_authenticated": false,
+  "is_client_muted": true
 }


### PR DESCRIPTION
A new API introduced in v36 that allows a client to signal whether
they're locally muted.
