### PR TITLE
feat(conference): call client_mute/client_unmute on v36 for signaling

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.0" />
+    <option name="version" value="2.0.10" />
   </component>
 </project>

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
@@ -107,6 +107,7 @@ public class InfinityConference private constructor(
         event = event,
         store = store,
         participantStep = step.participant(response.participantId),
+        versionId = response.version.versionId,
         directMedia = response.directMedia,
         iceServers = buildList(response.stun.size + response.turn.size) {
             this += response.stun.map { IceServer.Builder(it.url).build() }

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImplTest.kt
@@ -44,6 +44,7 @@ import com.pexip.sdk.api.infinity.UpdateResponse
 import com.pexip.sdk.api.infinity.UpdateSdpEvent
 import com.pexip.sdk.core.awaitSubscriptionCountAtLeast
 import com.pexip.sdk.infinity.CallId
+import com.pexip.sdk.infinity.Infinity
 import com.pexip.sdk.infinity.test.nextCallId
 import com.pexip.sdk.infinity.test.nextString
 import com.pexip.sdk.media.CandidateSignalingEvent
@@ -64,12 +65,14 @@ internal class MediaConnectionSignalingImplTest {
 
     private lateinit var store: TokenStore
     private lateinit var event: MutableSharedFlow<Event>
+    private lateinit var versionId: String
     private lateinit var iceServers: List<IceServer>
 
     @BeforeTest
     fun setUp() {
         store = TokenStore(Random.nextToken())
         event = MutableSharedFlow(extraBufferCapacity = 1)
+        versionId = Infinity.VERSION_35
         iceServers = List(10) {
             IceServer.Builder(listOf("turn:turn$it.example.com:347?transport=udp"))
                 .username("${it shl 1}")
@@ -89,6 +92,7 @@ internal class MediaConnectionSignalingImplTest {
                     event = event,
                     store = store,
                     participantStep = object : InfinityService.ParticipantStep {},
+                    versionId = versionId,
                     directMedia = it,
                     iceServers = iceServers,
                     iceTransportsRelayOnly = Random.nextBoolean(),
@@ -105,6 +109,7 @@ internal class MediaConnectionSignalingImplTest {
             event = event,
             store = store,
             participantStep = object : InfinityService.ParticipantStep {},
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -124,6 +129,7 @@ internal class MediaConnectionSignalingImplTest {
                     event = event,
                     store = store,
                     participantStep = object : InfinityService.ParticipantStep {},
+                    versionId = versionId,
                     directMedia = Random.nextBoolean(),
                     iceServers = iceServers,
                     iceTransportsRelayOnly = it,
@@ -141,6 +147,7 @@ internal class MediaConnectionSignalingImplTest {
             event = event,
             store = store,
             participantStep = object : InfinityService.ParticipantStep {},
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -157,6 +164,7 @@ internal class MediaConnectionSignalingImplTest {
             event = event,
             store = store,
             participantStep = participantStep,
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -183,6 +191,7 @@ internal class MediaConnectionSignalingImplTest {
             event = event,
             store = store,
             participantStep = participantStep,
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -209,6 +218,7 @@ internal class MediaConnectionSignalingImplTest {
             event = event,
             store = store,
             participantStep = participantStep,
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -242,6 +252,7 @@ internal class MediaConnectionSignalingImplTest {
             event = event,
             store = store,
             participantStep = participantStep,
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -264,6 +275,7 @@ internal class MediaConnectionSignalingImplTest {
             event = event,
             store = store,
             participantStep = participantStep,
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -323,6 +335,7 @@ internal class MediaConnectionSignalingImplTest {
                 event = event,
                 store = store,
                 participantStep = participantStep,
+                versionId = versionId,
                 directMedia = Random.nextBoolean(),
                 iceServers = iceServers,
                 iceTransportsRelayOnly = Random.nextBoolean(),
@@ -362,6 +375,7 @@ internal class MediaConnectionSignalingImplTest {
                 event = event,
                 store = store,
                 participantStep = object : InfinityService.ParticipantStep {},
+                versionId = versionId,
                 directMedia = Random.nextBoolean(),
                 iceServers = iceServers,
                 callStep = object : InfinityService.CallStep {
@@ -402,6 +416,7 @@ internal class MediaConnectionSignalingImplTest {
             event = event,
             store = store,
             participantStep = object : InfinityService.ParticipantStep {},
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             callStep = object : InfinityService.CallStep {
@@ -432,6 +447,7 @@ internal class MediaConnectionSignalingImplTest {
             event = event,
             store = store,
             participantStep = object : InfinityService.ParticipantStep {},
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             callStep = object : InfinityService.CallStep {
@@ -461,6 +477,7 @@ internal class MediaConnectionSignalingImplTest {
             event = event,
             store = store,
             participantStep = object : InfinityService.ParticipantStep {},
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             callStep = object : InfinityService.CallStep {
@@ -490,6 +507,7 @@ internal class MediaConnectionSignalingImplTest {
             event = event,
             store = store,
             participantStep = object : InfinityService.ParticipantStep {},
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             callStep = object : InfinityService.CallStep {
@@ -523,6 +541,7 @@ internal class MediaConnectionSignalingImplTest {
             event = event,
             store = store,
             participantStep = object : InfinityService.ParticipantStep {},
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             callStep = object : InfinityService.CallStep {
@@ -558,6 +577,33 @@ internal class MediaConnectionSignalingImplTest {
                     }
                 }
             },
+            versionId = versionId,
+            directMedia = Random.nextBoolean(),
+            iceServers = iceServers,
+            iceTransportsRelayOnly = Random.nextBoolean(),
+            dataChannel = null,
+        )
+        signaling.onAudioMuted()
+        called.join()
+    }
+
+    @Test
+    fun `onAudioMuted() returns on v36+`() = runTest {
+        val called = Job()
+        val signaling = MediaConnectionSignalingImpl(
+            scope = backgroundScope,
+            event = event,
+            store = store,
+            participantStep = object : InfinityService.ParticipantStep {
+                override fun clientMute(token: Token): Call<Unit> = object : TestCall<Unit> {
+                    override fun enqueue(callback: Callback<Unit>) {
+                        assertThat(token).isEqualTo(store.token.value)
+                        called.complete()
+                        callback.onSuccess(this, Unit)
+                    }
+                }
+            },
+            versionId = Infinity.VERSION_36,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -583,6 +629,33 @@ internal class MediaConnectionSignalingImplTest {
                     }
                 }
             },
+            versionId = versionId,
+            directMedia = Random.nextBoolean(),
+            iceServers = iceServers,
+            iceTransportsRelayOnly = Random.nextBoolean(),
+            dataChannel = null,
+        )
+        signaling.onAudioUnmuted()
+        called.join()
+    }
+
+    @Test
+    fun `onAudioUnmuted() returns on v36+`() = runTest {
+        val called = Job()
+        val signaling = MediaConnectionSignalingImpl(
+            scope = backgroundScope,
+            event = event,
+            store = store,
+            participantStep = object : InfinityService.ParticipantStep {
+                override fun clientUnmute(token: Token): Call<Unit> = object : TestCall<Unit> {
+                    override fun enqueue(callback: Callback<Unit>) {
+                        assertThat(token).isEqualTo(store.token.value)
+                        called.complete()
+                        callback.onSuccess(this, Unit)
+                    }
+                }
+            },
+            versionId = Infinity.VERSION_36,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -608,6 +681,7 @@ internal class MediaConnectionSignalingImplTest {
                     }
                 }
             },
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -633,6 +707,7 @@ internal class MediaConnectionSignalingImplTest {
                     }
                 }
             },
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -658,6 +733,7 @@ internal class MediaConnectionSignalingImplTest {
                     }
                 }
             },
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -683,6 +759,7 @@ internal class MediaConnectionSignalingImplTest {
                     }
                 }
             },
+            versionId = versionId,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),

--- a/sdk-infinity/api/sdk-infinity.api
+++ b/sdk-infinity/api/sdk-infinity.api
@@ -28,6 +28,12 @@ public final class com/pexip/sdk/infinity/CallId$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/pexip/sdk/infinity/Infinity {
+	public static final field INSTANCE Lcom/pexip/sdk/infinity/Infinity;
+	public static final field VERSION_35 Ljava/lang/String;
+	public static final field VERSION_36 Ljava/lang/String;
+}
+
 public final class com/pexip/sdk/infinity/LayoutId {
 	public static final field Companion Lcom/pexip/sdk/infinity/LayoutId$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/pexip/sdk/infinity/LayoutId;

--- a/sdk-infinity/src/commonMain/kotlin/com/pexip/sdk/infinity/Infinity.kt
+++ b/sdk-infinity/src/commonMain/kotlin/com/pexip/sdk/infinity/Infinity.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.infinity
+
+import com.pexip.sdk.core.InternalSdkApi
+
+@InternalSdkApi
+public object Infinity {
+
+    public const val VERSION_35: String = "35"
+
+    /**
+     * New APIs:
+     * - client_mute
+     * - client_unmute
+     * - is_client_muted
+     */
+    public const val VERSION_36: String = "36"
+}


### PR DESCRIPTION
This will correctly update `is_client_muted` on v36 and up, while using
the old `is_muted` on previous Infinity versions.
