### PR TITLE
feat(conference): add clientMute and clientUnmute to Roster

### DIFF
--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -1804,14 +1804,14 @@ public final class com/pexip/sdk/api/infinity/UpdateSdpEvent$Companion {
 
 public final class com/pexip/sdk/api/infinity/VersionResponse {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/VersionResponse$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
-	public final fun component1 ()Ljava/lang/String;
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1-WvCEiEU ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/VersionResponse;
-	public static synthetic fun copy$default (Lcom/pexip/sdk/api/infinity/VersionResponse;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/VersionResponse;
+	public final fun copy-O7OD61A (Ljava/lang/String;Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/VersionResponse;
+	public static synthetic fun copy-O7OD61A$default (Lcom/pexip/sdk/api/infinity/VersionResponse;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/VersionResponse;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getPseudoVersion ()Ljava/lang/String;
-	public final fun getVersionId ()Ljava/lang/String;
+	public final fun getVersionId-WvCEiEU ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
@@ -36,6 +36,7 @@ import com.pexip.sdk.infinity.ServiceType
 import com.pexip.sdk.infinity.test.nextLayoutId
 import com.pexip.sdk.infinity.test.nextParticipantId
 import com.pexip.sdk.infinity.test.nextString
+import com.pexip.sdk.infinity.test.nextVersionId
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -264,7 +265,7 @@ internal class ConferenceStepTest {
                     guestsCanPresent = Random.nextBoolean(),
                     serviceType = ServiceType.entries.random(),
                     version = VersionResponse(
-                        versionId = Random.nextString(),
+                        versionId = Random.nextVersionId(),
                         pseudoVersion = Random.nextString(),
                     ),
                     stun = List(10) {

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/RegistrationStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/RegistrationStepTest.kt
@@ -23,6 +23,7 @@ import assertk.assertions.isInstanceOf
 import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.infinity.test.nextRegistrationId
 import com.pexip.sdk.infinity.test.nextString
+import com.pexip.sdk.infinity.test.nextVersionId
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -107,7 +108,7 @@ internal class RegistrationStepTest {
             directoryEnabled = Random.nextBoolean(),
             routeViaRegistrar = Random.nextBoolean(),
             version = VersionResponse(
-                versionId = Random.nextString(),
+                versionId = Random.nextVersionId(),
                 pseudoVersion = Random.nextString(),
             ),
         )

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/RequestTokenResponseSerializerTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/RequestTokenResponseSerializerTest.kt
@@ -24,6 +24,7 @@ import com.pexip.sdk.api.infinity.VersionResponse
 import com.pexip.sdk.api.infinity.readUtf8
 import com.pexip.sdk.infinity.ParticipantId
 import com.pexip.sdk.infinity.ServiceType
+import com.pexip.sdk.infinity.VersionId
 import kotlinx.serialization.json.Json
 import okio.FileSystem
 import kotlin.test.BeforeTest
@@ -53,7 +54,7 @@ class RequestTokenResponseSerializerTest {
                     participantId = ParticipantId("f22f8f50-0d85-47ea-bbf7-97f4eaa39f53"),
                     participantName = "George",
                     version = VersionResponse(
-                        versionId = "35",
+                        versionId = VersionId.V35,
                         pseudoVersion = "77524.0.0",
                     ),
                     chatEnabled = true,
@@ -73,7 +74,7 @@ class RequestTokenResponseSerializerTest {
                     participantId = ParticipantId("614221f4-3a5c-4d1f-8df6-3ae27188df54"),
                     participantName = "George",
                     version = VersionResponse(
-                        versionId = "36",
+                        versionId = VersionId.V36,
                         pseudoVersion = "79019.0.0",
                     ),
                     chatEnabled = true,

--- a/sdk-conference/api/sdk-conference.api
+++ b/sdk-conference/api/sdk-conference.api
@@ -4,6 +4,18 @@ public final class com/pexip/sdk/conference/AdmitException : java/lang/RuntimeEx
 	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public final class com/pexip/sdk/conference/ClientMuteException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
+public final class com/pexip/sdk/conference/ClientUnmuteException : java/lang/RuntimeException {
+	public fun <init> ()V
+	public fun <init> (Ljava/lang/Throwable;)V
+	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public abstract interface class com/pexip/sdk/conference/Conference {
 	public abstract fun getMessenger ()Lcom/pexip/sdk/conference/Messenger;
 	public abstract fun getName ()Ljava/lang/String;
@@ -292,6 +304,10 @@ public abstract interface class com/pexip/sdk/conference/Referer {
 public abstract interface class com/pexip/sdk/conference/Roster {
 	public fun admit-5K0EZTY (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun admit-5K0EZTY$suspendImpl (Lcom/pexip/sdk/conference/Roster;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun clientMute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun clientMute$suspendImpl (Lcom/pexip/sdk/conference/Roster;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun clientUnmute (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun clientUnmute$suspendImpl (Lcom/pexip/sdk/conference/Roster;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun disconnect-mpzmtw0 (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun disconnect-mpzmtw0$default (Lcom/pexip/sdk/conference/Roster;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static synthetic fun disconnect-mpzmtw0$suspendImpl (Lcom/pexip/sdk/conference/Roster;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/ClientMuteException.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/ClientMuteException.kt
@@ -13,20 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.pexip.sdk.infinity
+package com.pexip.sdk.conference
 
-import com.pexip.sdk.core.InternalSdkApi
-
-@InternalSdkApi
-public object Infinity {
-
-    public const val VERSION_35: String = "35"
-
-    /**
-     * New APIs:
-     * - client_mute
-     * - client_unmute
-     * - is_client_muted
-     */
-    public const val VERSION_36: String = "36"
-}
+/**
+ * Thrown to indicate that client mute failed.
+ *
+ * @property cause a cause of this exception
+ */
+public class ClientMuteException @JvmOverloads constructor(cause: Throwable? = null) : RuntimeException("Failed to mute client.", cause)

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/ClientUnmuteException.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/ClientUnmuteException.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Pexip AS
+ * Copyright 2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,16 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.pexip.sdk.api.infinity
+package com.pexip.sdk.conference
 
-import com.pexip.sdk.infinity.VersionId
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
-public data class VersionResponse(
-    @SerialName("version_id")
-    val versionId: VersionId,
-    @SerialName("pseudo_version")
-    val pseudoVersion: String,
-)
+/**
+ * Thrown to indicate that client unmute failed.
+ *
+ * @property cause a cause of this exception
+ */
+public class ClientUnmuteException @JvmOverloads constructor(cause: Throwable? = null) : RuntimeException("Failed to unmute client.", cause)

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Roster.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Roster.kt
@@ -97,6 +97,24 @@ public interface Roster {
         throw NotImplementedError()
 
     /**
+     * Signals that the local microphone has been muted.
+     *
+     * Can only be called on self.
+     *
+     * @throws ClientMuteException if the operation failed
+     */
+    public suspend fun clientMute(): Unit = throw NotImplementedError()
+
+    /**
+     * Signals that the local microphone has been unmuted.
+     *
+     * Can only be called on self.
+     *
+     * @throws ClientUnmuteException if the operation failed
+     */
+    public suspend fun clientUnmute(): Unit = throw NotImplementedError()
+
+    /**
      * Mutes the specified participant or self.
      *
      * @param participantId an ID of the participant, null for self

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
@@ -39,6 +39,7 @@ import com.pexip.sdk.core.WhileSubscribedWithDebounce
 import com.pexip.sdk.core.retry
 import com.pexip.sdk.infinity.ServiceType
 import com.pexip.sdk.infinity.UnsupportedInfinityException
+import com.pexip.sdk.infinity.VersionId
 import com.pexip.sdk.media.IceServer
 import com.pexip.sdk.media.MediaConnectionSignaling
 import kotlinx.coroutines.CoroutineScope
@@ -90,6 +91,7 @@ public class InfinityConference private constructor(
     override val roster: Roster = RosterImpl(
         scope = scope,
         event = event,
+        versionId = response.version.versionId,
         participantId = response.participantId,
         parentParticipantId = response.parentParticipantId,
         store = store,
@@ -214,7 +216,7 @@ public class InfinityConference private constructor(
             step: InfinityService.ConferenceStep,
             response: RequestTokenResponse,
         ): InfinityConference {
-            if (response.version.versionId < "29") {
+            if (response.version.versionId < VersionId.V29) {
                 throw UnsupportedInfinityException(response.version.versionId)
             }
             return InfinityConference(step, response)

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImpl.kt
@@ -30,7 +30,7 @@ import com.pexip.sdk.api.infinity.TokenStore
 import com.pexip.sdk.api.infinity.UpdateRequest
 import com.pexip.sdk.api.infinity.UpdateSdpEvent
 import com.pexip.sdk.core.retry
-import com.pexip.sdk.infinity.Infinity
+import com.pexip.sdk.infinity.VersionId
 import com.pexip.sdk.media.CandidateSignalingEvent
 import com.pexip.sdk.media.Data
 import com.pexip.sdk.media.DataSender
@@ -52,7 +52,7 @@ internal class MediaConnectionSignalingImpl(
     event: Flow<Event>,
     private val store: TokenStore,
     private val participantStep: InfinityService.ParticipantStep,
-    private val versionId: String,
+    private val versionId: VersionId,
     override val directMedia: Boolean,
     override val iceServers: List<IceServer>,
     override val iceTransportsRelayOnly: Boolean,
@@ -138,7 +138,7 @@ internal class MediaConnectionSignalingImpl(
 
     override suspend fun onAudioMuted() = retry {
         val token = store.token.value
-        val call = when (versionId >= Infinity.VERSION_36) {
+        val call = when (versionId >= VersionId.V36) {
             true -> participantStep.clientMute(token)
             else -> participantStep.mute(token)
         }
@@ -147,7 +147,7 @@ internal class MediaConnectionSignalingImpl(
 
     override suspend fun onAudioUnmuted() = retry {
         val token = store.token.value
-        val call = when (versionId >= Infinity.VERSION_36) {
+        val call = when (versionId >= VersionId.V36) {
             true -> participantStep.clientUnmute(token)
             else -> participantStep.unmute(token)
         }

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImplTest.kt
@@ -44,7 +44,7 @@ import com.pexip.sdk.api.infinity.UpdateResponse
 import com.pexip.sdk.api.infinity.UpdateSdpEvent
 import com.pexip.sdk.core.awaitSubscriptionCountAtLeast
 import com.pexip.sdk.infinity.CallId
-import com.pexip.sdk.infinity.Infinity
+import com.pexip.sdk.infinity.VersionId
 import com.pexip.sdk.infinity.test.nextCallId
 import com.pexip.sdk.infinity.test.nextString
 import com.pexip.sdk.media.CandidateSignalingEvent
@@ -65,14 +65,14 @@ internal class MediaConnectionSignalingImplTest {
 
     private lateinit var store: TokenStore
     private lateinit var event: MutableSharedFlow<Event>
-    private lateinit var versionId: String
     private lateinit var iceServers: List<IceServer>
+
+    private val versionId = VersionId.V35
 
     @BeforeTest
     fun setUp() {
         store = TokenStore(Random.nextToken())
         event = MutableSharedFlow(extraBufferCapacity = 1)
-        versionId = Infinity.VERSION_35
         iceServers = List(10) {
             IceServer.Builder(listOf("turn:turn$it.example.com:347?transport=udp"))
                 .username("${it shl 1}")
@@ -603,7 +603,7 @@ internal class MediaConnectionSignalingImplTest {
                     }
                 }
             },
-            versionId = Infinity.VERSION_36,
+            versionId = VersionId.V36,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),
@@ -655,7 +655,7 @@ internal class MediaConnectionSignalingImplTest {
                     }
                 }
             },
-            versionId = Infinity.VERSION_36,
+            versionId = VersionId.V36,
             directMedia = Random.nextBoolean(),
             iceServers = iceServers,
             iceTransportsRelayOnly = Random.nextBoolean(),

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RefererTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RefererTest.kt
@@ -37,6 +37,7 @@ import com.pexip.sdk.conference.Theme
 import com.pexip.sdk.infinity.ServiceType
 import com.pexip.sdk.infinity.test.nextParticipantId
 import com.pexip.sdk.infinity.test.nextString
+import com.pexip.sdk.infinity.test.nextVersionId
 import com.pexip.sdk.media.MediaConnectionSignaling
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
@@ -99,7 +100,10 @@ class RefererTest {
             participantId = Random.nextParticipantId(),
             participantName = Random.nextString(),
             directMediaRequested = Random.nextBoolean(),
-            version = VersionResponse(Random.nextString(), Random.nextString()),
+            version = VersionResponse(
+                versionId = Random.nextVersionId(),
+                pseudoVersion = Random.nextString(),
+            ),
             callTag = callTag,
         )
         val step = object : InfinityService.ConferenceStep {

--- a/sdk-infinity-test/api/sdk-infinity-test.api
+++ b/sdk-infinity-test/api/sdk-infinity-test.api
@@ -5,5 +5,6 @@ public final class com/pexip/sdk/infinity/test/RandomKt {
 	public static final fun nextRegistrationId (Lkotlin/random/Random;)Ljava/lang/String;
 	public static final fun nextString (Lkotlin/random/Random;I)Ljava/lang/String;
 	public static synthetic fun nextString$default (Lkotlin/random/Random;IILjava/lang/Object;)Ljava/lang/String;
+	public static final fun nextVersionId (Lkotlin/random/Random;)Ljava/lang/String;
 }
 

--- a/sdk-infinity-test/src/commonMain/kotlin/com/pexip/sdk/infinity/test/Random.kt
+++ b/sdk-infinity-test/src/commonMain/kotlin/com/pexip/sdk/infinity/test/Random.kt
@@ -19,6 +19,7 @@ import com.pexip.sdk.infinity.CallId
 import com.pexip.sdk.infinity.LayoutId
 import com.pexip.sdk.infinity.ParticipantId
 import com.pexip.sdk.infinity.RegistrationId
+import com.pexip.sdk.infinity.VersionId
 import kotlin.random.Random
 
 private const val CHARACTERS = "_-0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -51,3 +52,8 @@ public fun Random.nextParticipantId(): ParticipantId = ParticipantId(nextString(
  * Gets the next random [RegistrationId] from the random number generator.
  */
 public fun Random.nextRegistrationId(): RegistrationId = RegistrationId(nextString())
+
+/**
+ * Gets the next random [VersionId] from the random number generator.
+ */
+public fun Random.nextVersionId(): VersionId = VersionId(nextString())

--- a/sdk-infinity/api/sdk-infinity.api
+++ b/sdk-infinity/api/sdk-infinity.api
@@ -28,12 +28,6 @@ public final class com/pexip/sdk/infinity/CallId$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/infinity/Infinity {
-	public static final field INSTANCE Lcom/pexip/sdk/infinity/Infinity;
-	public static final field VERSION_35 Ljava/lang/String;
-	public static final field VERSION_36 Ljava/lang/String;
-}
-
 public final class com/pexip/sdk/infinity/LayoutId {
 	public static final field Companion Lcom/pexip/sdk/infinity/LayoutId$Companion;
 	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/pexip/sdk/infinity/LayoutId;
@@ -221,7 +215,44 @@ public final class com/pexip/sdk/infinity/ServiceType$Companion {
 }
 
 public final class com/pexip/sdk/infinity/UnsupportedInfinityException : java/lang/IllegalArgumentException {
-	public fun <init> (Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getVersion ()Ljava/lang/String;
+	public final fun getVersionId-WvCEiEU ()Ljava/lang/String;
+}
+
+public final class com/pexip/sdk/infinity/VersionId : java/lang/Comparable {
+	public static final field Companion Lcom/pexip/sdk/infinity/VersionId$Companion;
+	public static final synthetic fun box-impl (Ljava/lang/String;)Lcom/pexip/sdk/infinity/VersionId;
+	public synthetic fun compareTo (Ljava/lang/Object;)I
+	public fun compareTo-nWcezAY (Ljava/lang/String;)I
+	public static fun compareTo-nWcezAY (Ljava/lang/String;Ljava/lang/String;)I
+	public static fun constructor-impl (Ljava/lang/String;)Ljava/lang/String;
+	public fun equals (Ljava/lang/Object;)Z
+	public static fun equals-impl (Ljava/lang/String;Ljava/lang/Object;)Z
+	public static final fun equals-impl0 (Ljava/lang/String;Ljava/lang/String;)Z
+	public final fun getValue ()Ljava/lang/String;
+	public fun hashCode ()I
+	public static fun hashCode-impl (Ljava/lang/String;)I
+	public fun toString ()Ljava/lang/String;
+	public static fun toString-impl (Ljava/lang/String;)Ljava/lang/String;
+	public final synthetic fun unbox-impl ()Ljava/lang/String;
+}
+
+public synthetic class com/pexip/sdk/infinity/VersionId$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Lcom/pexip/sdk/infinity/VersionId$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun deserialize-htA5qwM (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/String;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public final fun serialize-AL5BK0g (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/String;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class com/pexip/sdk/infinity/VersionId$Companion {
+	public final fun getV29-WvCEiEU ()Ljava/lang/String;
+	public final fun getV35-WvCEiEU ()Ljava/lang/String;
+	public final fun getV36-WvCEiEU ()Ljava/lang/String;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/sdk-infinity/src/commonMain/kotlin/com/pexip/sdk/infinity/UnsupportedInfinityException.kt
+++ b/sdk-infinity/src/commonMain/kotlin/com/pexip/sdk/infinity/UnsupportedInfinityException.kt
@@ -18,7 +18,16 @@ package com.pexip.sdk.infinity
 /**
  * Thrown to indicate that the Infinity deployment is not supported
  *
- * @property version a version of Infinity that caused this exception
+ * @property versionId a version of Infinity that caused this exception
  */
-public class UnsupportedInfinityException(public val version: String) :
-    IllegalArgumentException("Infinity $version is not supported by the SDK. Please upgrade your Infinity deployment to 29 or newer.")
+public class UnsupportedInfinityException(public val versionId: VersionId) : IllegalArgumentException("Infinity $versionId is not supported by the SDK. Please upgrade your Infinity deployment to 29 or newer.") {
+
+    /**
+     * A version of Infinity that caused this exception
+     */
+    @Deprecated(
+        message = "Use versionId instead.",
+        replaceWith = ReplaceWith(expression = "versionId.value"),
+    )
+    public val version: String get() = versionId.value
+}

--- a/sdk-infinity/src/commonMain/kotlin/com/pexip/sdk/infinity/VersionId.kt
+++ b/sdk-infinity/src/commonMain/kotlin/com/pexip/sdk/infinity/VersionId.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.infinity
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A unique identifier for the Infinity version.
+ *
+ * @property value a unique identifier for the Infinity version.
+ */
+@Serializable
+@JvmInline
+public value class VersionId(public val value: String) : Comparable<VersionId> {
+
+    override fun compareTo(other: VersionId): Int = value.compareTo(other.value)
+
+    override fun toString(): String = value
+
+    public companion object {
+
+        public val V29: VersionId = VersionId("29")
+        public val V35: VersionId = VersionId("35")
+
+        /**
+         * New APIs:
+         * - client_mute
+         * - client_unmute
+         * - is_client_muted
+         */
+        public val V36: VersionId = VersionId("36")
+    }
+}

--- a/sdk-registration/src/main/kotlin/com/pexip/sdk/registration/infinity/InfinityRegistration.kt
+++ b/sdk-registration/src/main/kotlin/com/pexip/sdk/registration/infinity/InfinityRegistration.kt
@@ -22,6 +22,7 @@ import com.pexip.sdk.api.infinity.TokenStore
 import com.pexip.sdk.core.WhileSubscribedWithDebounce
 import com.pexip.sdk.core.retry
 import com.pexip.sdk.infinity.UnsupportedInfinityException
+import com.pexip.sdk.infinity.VersionId
 import com.pexip.sdk.registration.RegisteredDevicesCallback
 import com.pexip.sdk.registration.Registration
 import com.pexip.sdk.registration.RegistrationEvent
@@ -150,7 +151,7 @@ public class InfinityRegistration private constructor(
             step: InfinityService.RegistrationStep,
             response: RequestRegistrationTokenResponse,
         ): InfinityRegistration {
-            if (response.version.versionId < "29") {
+            if (response.version.versionId < VersionId.V29) {
                 throw UnsupportedInfinityException(response.version.versionId)
             }
             return InfinityRegistration(step, response)


### PR DESCRIPTION
This is only really useful when the media is provided by some other
means (e.g. SIP) and we want to sync local mute state with Infinity.
