### PR TITLE
feat(conference): add a way to observe guestsCanUnmute state

### DIFF
--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -165,15 +165,17 @@ public final class com/pexip/sdk/api/infinity/CallsResponse$Companion {
 public final class com/pexip/sdk/api/infinity/ConferenceUpdateEvent : com/pexip/sdk/api/Event {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/ConferenceUpdateEvent$Companion;
 	public fun <init> ()V
-	public fun <init> (ZZZZ)V
-	public synthetic fun <init> (ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZZLjava/lang/Boolean;)V
+	public synthetic fun <init> (ZZZZLjava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
 	public final fun component4 ()Z
-	public final fun copy (ZZZZ)Lcom/pexip/sdk/api/infinity/ConferenceUpdateEvent;
-	public static synthetic fun copy$default (Lcom/pexip/sdk/api/infinity/ConferenceUpdateEvent;ZZZZILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/ConferenceUpdateEvent;
+	public final fun component5 ()Ljava/lang/Boolean;
+	public final fun copy (ZZZZLjava/lang/Boolean;)Lcom/pexip/sdk/api/infinity/ConferenceUpdateEvent;
+	public static synthetic fun copy$default (Lcom/pexip/sdk/api/infinity/ConferenceUpdateEvent;ZZZZLjava/lang/Boolean;ILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/ConferenceUpdateEvent;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getGuestsCanUnmute ()Ljava/lang/Boolean;
 	public final fun getGuestsMuted ()Z
 	public final fun getLocked ()Z
 	public final fun getPresentationAllowed ()Z

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/Event.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/Event.kt
@@ -37,6 +37,8 @@ public data class ConferenceUpdateEvent(
     val guestsMuted: Boolean = false,
     @SerialName("presentation_allowed")
     val presentationAllowed: Boolean = false,
+    @SerialName("guests_can_unmute")
+    val guestsCanUnmute: Boolean? = null,
 ) : Event
 
 @Serializable

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/EventTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/EventTest.kt
@@ -323,6 +323,7 @@ internal class EventTest {
                     started = true,
                     guestsMuted = false,
                     presentationAllowed = true,
+                    guestsCanUnmute = false,
                 ),
             )
             .row(

--- a/sdk-api/src/test/resources/conference_update.json
+++ b/sdk-api/src/test/resources/conference_update.json
@@ -10,5 +10,6 @@
     "current": null
   },
   "breakout_rooms": false,
+  "guests_can_unmute": false,
   "live_captions_available": true
 }

--- a/sdk-conference/api/sdk-conference.api
+++ b/sdk-conference/api/sdk-conference.api
@@ -315,6 +315,7 @@ public abstract interface class com/pexip/sdk/conference/Roster {
 	public fun disconnectAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun disconnectAll$suspendImpl (Lcom/pexip/sdk/conference/Roster;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun getAllGuestsMuted ()Lkotlinx/coroutines/flow/StateFlow;
+	public fun getGuestsCanUnmute ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getLocked ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getMe ()Lkotlinx/coroutines/flow/StateFlow;
 	public fun getParticipants ()Lkotlinx/coroutines/flow/StateFlow;

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Roster.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Roster.kt
@@ -62,6 +62,18 @@ public interface Roster {
         get() = throw NotImplementedError()
 
     /**
+     * A [StateFlow] that represents whether guests in the conference can unmute themselves, or null.
+     *
+     * Null signals whether that particular instance of Infinity supports modifying this property
+     * and can be used to hide/show the appropriate UI controls without additional version checks.
+     *
+     * When muted, no guest participants can speak unless they are explicitly unmuted.
+     * This setting is only available to conference hosts.
+     */
+    public val guestsCanUnmute: StateFlow<Boolean?>
+        get() = throw NotImplementedError()
+
+    /**
      * Lets a specified participant into the conference from the waiting room of a locked conference.
      *
      * @param participantId an ID of the participant

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImpl.kt
@@ -184,6 +184,11 @@ internal class RosterImpl(
         .map { it.guestsMuted }
         .stateIn(scope, SharingStarted.Eagerly, false)
 
+    override val guestsCanUnmute: StateFlow<Boolean?> = event
+        .filterIsInstance<ConferenceUpdateEvent>()
+        .map { it.guestsCanUnmute }
+        .stateIn(scope, SharingStarted.Eagerly, null)
+
     override suspend fun admit(participantId: ParticipantId) {
         perform(participantId, ParticipantStep::unlock, ::AdmitException)
     }

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImplTest.kt
@@ -28,6 +28,7 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isIn
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
 import assertk.assertions.isNull
 import assertk.assertions.isTrue
 import assertk.fail
@@ -130,6 +131,11 @@ class RosterImplTest {
     @Test
     fun `allGuestsMuted produces the correct all guests muted state`() {
         table.forAll(::`allGuestsMuted produces the correct all guests muted state`)
+    }
+
+    @Test
+    fun `guestsCanUnmute produces the correct guests can unmute state`() {
+        table.forAll(::`guestsCanUnmute produces the correct guests can unmute state`)
     }
 
     @Test
@@ -703,6 +709,28 @@ class RosterImplTest {
             expectNoEvents()
             event.emit(ConferenceUpdateEvent(guestsMuted = false))
             assertThat(awaitItem(), "guestsMuted").isFalse()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    private fun `guestsCanUnmute produces the correct guests can unmute state`(
+        participantId: ParticipantId,
+        parentParticipantId: ParticipantId?,
+    ) = runTest {
+        val roster = RosterImpl(participantId, parentParticipantId)
+        roster.guestsCanUnmute.test {
+            event.subscriptionCount.first { it > 0 }
+            assertThat(awaitItem(), "guestsMuted").isNull()
+            event.emit(ConferenceUpdateEvent(guestsCanUnmute = true))
+            assertThat(awaitItem(), "guestsMuted")
+                .isNotNull()
+                .isTrue()
+            event.emit(ConferenceUpdateEvent(guestsCanUnmute = true))
+            expectNoEvents()
+            event.emit(ConferenceUpdateEvent(guestsCanUnmute = false))
+            assertThat(awaitItem(), "guestsMuted")
+                .isNotNull()
+                .isFalse()
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
This is a new v36 API that allows hosts to forbid guests from unmuting
themselves.
