### PR TITLE
feat: set jvm toolchain to 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Required JDK to 17
+
 ## [0.16.0] - 2024-10-02
 
 ### Added

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/AndroidApplicationPlugin.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/AndroidApplicationPlugin.kt
@@ -17,12 +17,13 @@ package com.pexip.sdk
 
 import com.android.build.api.dsl.ApplicationExtension
 import com.pexip.sdk.internal.Android
+import com.pexip.sdk.internal.Jvm
+import com.pexip.sdk.internal.languageVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.withType
 
@@ -42,8 +43,7 @@ class AndroidApplicationPlugin : Plugin<Project> {
                 buildConfig = true
             }
             compileOptions {
-                sourceCompatibility = Android.sourceCompatibility
-                targetCompatibility = Android.targetCompatibility
+                languageVersion(Jvm.languageVersion)
             }
             testOptions {
                 unitTests {
@@ -60,7 +60,7 @@ class AndroidApplicationPlugin : Plugin<Project> {
         }
         configure<JavaPluginExtension> {
             toolchain {
-                languageVersion.set(JavaLanguageVersion.of(11))
+                languageVersion.set(Jvm.languageVersion)
             }
         }
         tasks.withType<Test>().configureEach {

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/AndroidLibraryPlugin.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/AndroidLibraryPlugin.kt
@@ -17,12 +17,13 @@ package com.pexip.sdk
 
 import com.android.build.api.dsl.LibraryExtension
 import com.pexip.sdk.internal.Android
+import com.pexip.sdk.internal.Jvm
+import com.pexip.sdk.internal.languageVersion
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.tasks.testing.Test
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
-import org.gradle.jvm.toolchain.JavaLanguageVersion
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.withType
 
@@ -41,8 +42,7 @@ class AndroidLibraryPlugin : Plugin<Project> {
                 buildConfig = false
             }
             compileOptions {
-                sourceCompatibility = Android.sourceCompatibility
-                targetCompatibility = Android.targetCompatibility
+                languageVersion(Jvm.languageVersion)
             }
             testOptions {
                 unitTests {
@@ -52,7 +52,7 @@ class AndroidLibraryPlugin : Plugin<Project> {
         }
         configure<JavaPluginExtension> {
             toolchain {
-                languageVersion.set(JavaLanguageVersion.of(11))
+                languageVersion.set(Jvm.languageVersion)
             }
         }
         tasks.withType<Test>().configureEach {

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinAndroidLibraryPublishingPlugin.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinAndroidLibraryPublishingPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Pexip AS
+ * Copyright 2023-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
+import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.get
@@ -40,16 +41,20 @@ class KotlinAndroidLibraryPublishingPlugin : Plugin<Project> {
         configure<LibraryExtension> {
             publishing {
                 singleVariant("release") {
-                    withJavadocJar()
                     withSourcesJar()
                 }
             }
+        }
+        val javadocJar = tasks.register<Jar>("dokkaJavadocJar") {
+            from(tasks.named("dokkaJavadoc"))
+            archiveClassifier.set("javadoc")
         }
         configure<PublishingExtension> {
             publications {
                 register<MavenPublication>("release") {
                     afterEvaluate {
                         from(components["release"])
+                        artifact(javadocJar)
                     }
                 }
             }

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinJvmPlugin.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinJvmPlugin.kt
@@ -15,7 +15,9 @@
  */
 package com.pexip.sdk
 
+import com.pexip.sdk.internal.Jvm
 import com.pexip.sdk.internal.assertk
+import com.pexip.sdk.internal.jvmToolchain
 import com.pexip.sdk.internal.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -36,7 +38,7 @@ class KotlinJvmPlugin : Plugin<Project> {
         }
         with(kotlinExtension) {
             explicitApi()
-            jvmToolchain(11)
+            jvmToolchain(Jvm.languageVersion)
         }
         dependencies {
             "testImplementation"(kotlin("test-junit"))

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinMultiplatformPlugin.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinMultiplatformPlugin.kt
@@ -15,7 +15,9 @@
  */
 package com.pexip.sdk
 
+import com.pexip.sdk.internal.Jvm
 import com.pexip.sdk.internal.assertk
+import com.pexip.sdk.internal.jvmToolchain
 import com.pexip.sdk.internal.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -34,7 +36,7 @@ class KotlinMultiplatformPlugin : Plugin<Project> {
         }
         with(kotlinExtension) {
             explicitApi()
-            jvmToolchain(11)
+            jvmToolchain(Jvm.languageVersion)
             sourceSets.named("commonTest") {
                 dependencies {
                     implementation(kotlin("test"))

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/internal/CompileOptions.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/internal/CompileOptions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Pexip AS
+ * Copyright 2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,12 @@
  */
 package com.pexip.sdk.internal
 
-internal object Android {
+import com.android.build.api.dsl.CompileOptions
+import com.android.build.gradle.tasks.asJavaVersion
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 
-    const val MIN_SDK = 21
-    const val TARGET_SDK = 34
-    const val COMPILE_SDK = 34
-
-    const val TEST_INSTRUMENTATION_RUNNER = "androidx.test.runner.AndroidJUnitRunner"
+internal fun CompileOptions.languageVersion(version: JavaLanguageVersion) {
+    val javaVersion = version.asJavaVersion()
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
 }

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/internal/Jvm.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/internal/Jvm.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Pexip AS
+ * Copyright 2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,9 @@
  */
 package com.pexip.sdk.internal
 
-internal object Android {
+import org.gradle.jvm.toolchain.JavaLanguageVersion
 
-    const val MIN_SDK = 21
-    const val TARGET_SDK = 34
-    const val COMPILE_SDK = 34
+internal object Jvm {
 
-    const val TEST_INSTRUMENTATION_RUNNER = "androidx.test.runner.AndroidJUnitRunner"
+    val languageVersion = JavaLanguageVersion.of(17)
 }

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/internal/KotlinTopLevelExtension.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/internal/KotlinTopLevelExtension.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Pexip AS
+ * Copyright 2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,11 +15,9 @@
  */
 package com.pexip.sdk.internal
 
-internal object Android {
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtension
 
-    const val MIN_SDK = 21
-    const val TARGET_SDK = 34
-    const val COMPILE_SDK = 34
-
-    const val TEST_INSTRUMENTATION_RUNNER = "androidx.test.runner.AndroidJUnitRunner"
+fun KotlinTopLevelExtension.jvmToolchain(version: JavaLanguageVersion) {
+    jvmToolchain(version.asInt())
 }


### PR DESCRIPTION
This is mostly brought up by updates to WebRTC (required JDK17) and has
been generally supported by Android for some time now.
