### PR TITLE
refactor(api): move await to Call, asFlow to EventSourceFactory

### DIFF
--- a/sample/src/main/kotlin/com/pexip/sdk/sample/pinchallenge/PinChallengeWorkflow.kt
+++ b/sample/src/main/kotlin/com/pexip/sdk/sample/pinchallenge/PinChallengeWorkflow.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 package com.pexip.sdk.sample.pinchallenge
 
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.InvalidPinException
 import com.pexip.sdk.api.infinity.RequestTokenRequest
@@ -36,8 +35,7 @@ import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
-class PinChallengeWorkflow @Inject constructor(private val store: SettingsStore) :
-    StatefulWorkflow<PinChallengeProps, PinChallengeState, PinChallengeOutput, PinChallengeRendering>() {
+class PinChallengeWorkflow @Inject constructor(private val store: SettingsStore) : StatefulWorkflow<PinChallengeProps, PinChallengeState, PinChallengeOutput, PinChallengeRendering>() {
 
     override fun initialState(props: PinChallengeProps, snapshot: Snapshot?): PinChallengeState =
         PinChallengeState()

--- a/sample/src/main/kotlin/com/pexip/sdk/sample/pinrequirement/PinRequirementWorkflow.kt
+++ b/sample/src/main/kotlin/com/pexip/sdk/sample/pinrequirement/PinRequirementWorkflow.kt
@@ -15,7 +15,6 @@
  */
 package com.pexip.sdk.sample.pinrequirement
 
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.RequestTokenRequest
 import com.pexip.sdk.api.infinity.RequiredPinException

--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -1,4 +1,5 @@
 public abstract interface class com/pexip/sdk/api/Call {
+	public abstract fun await (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun cancel ()V
 	public abstract fun enqueue (Lcom/pexip/sdk/api/Callback;)V
 	public abstract fun execute ()Ljava/lang/Object;
@@ -17,6 +18,7 @@ public abstract interface class com/pexip/sdk/api/EventSource {
 }
 
 public abstract interface class com/pexip/sdk/api/EventSourceFactory {
+	public fun asFlow ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun create (Lcom/pexip/sdk/api/EventSourceListener;)Lcom/pexip/sdk/api/EventSource;
 }
 

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/Call.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/Call.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,13 @@ package com.pexip.sdk.api
  * Represents an API call.
  */
 public interface Call<T> {
+
+    /**
+     * Suspends until the [Call] completes with either success or failure.
+     *
+     * @return successful response body
+     */
+    public suspend fun await(): T
 
     /**
      * Executes the call on the caller thread.

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/coroutines/CallUtil.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/coroutines/CallUtil.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,20 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:Suppress("EXTENSION_SHADOWED_BY_MEMBER")
+
 package com.pexip.sdk.api.coroutines
 
 import com.pexip.sdk.api.Call
-import com.pexip.sdk.api.Callback
 import com.pexip.sdk.api.Event
-import com.pexip.sdk.api.EventSource
 import com.pexip.sdk.api.EventSourceFactory
-import com.pexip.sdk.api.EventSourceListener
-import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 /**
  * Suspends until the [Call] completes with either success or failure.
@@ -34,37 +28,13 @@ import kotlin.coroutines.resumeWithException
  * @param T successful response body type
  * @return successful response body
  */
-public suspend fun <T> Call<T>.await(): T = suspendCancellableCoroutine {
-    it.invokeOnCancellation { cancel() }
-    val callback = object : Callback<T> {
-
-        override fun onSuccess(call: Call<T>, response: T) = it.resume(response)
-
-        override fun onFailure(call: Call<T>, t: Throwable) = it.resumeWithException(t)
-    }
-    enqueue(callback)
-}
+@Deprecated("Moved to Call", level = DeprecationLevel.ERROR)
+public suspend fun <T> Call<T>.await(): T = await()
 
 /**
  * Converts this [EventSourceFactory] to a [Flow].
  *
  * @return a [Flow] of [Event]s
  */
-public fun EventSourceFactory.asFlow(): Flow<Event> = callbackFlow {
-    val listener = object : EventSourceListener {
-
-        override fun onOpen(eventSource: EventSource) {
-            // noop
-        }
-
-        override fun onEvent(eventSource: EventSource, event: Event) {
-            trySend(event)
-        }
-
-        override fun onClosed(eventSource: EventSource, t: Throwable?) {
-            close(t)
-        }
-    }
-    val source = create(listener)
-    awaitClose { source.cancel() }
-}
+@Deprecated("Moved to EventSourceFactory", level = DeprecationLevel.ERROR)
+public fun EventSourceFactory.asFlow(): Flow<Event> = asFlow()

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RealNodeResolver.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RealNodeResolver.kt
@@ -20,6 +20,8 @@ package com.pexip.sdk.api.infinity.internal
 import com.pexip.sdk.api.Call
 import com.pexip.sdk.api.Callback
 import com.pexip.sdk.api.infinity.NodeResolver
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import org.minidns.hla.ResolverApi
 import java.net.InetAddress
 import java.net.URL
@@ -39,6 +41,10 @@ internal class RealNodeResolver(private val api: ResolverApi) : NodeResolver {
 
         private val executed = AtomicBoolean()
         private var future = AtomicReference<Future<*>?>()
+
+        override suspend fun await(): List<URL> = maybeExecute {
+            withContext(Dispatchers.IO) { resolve(host) }
+        }
 
         override fun execute(): List<URL> = maybeExecute { resolve(host) }
 

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/CallStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/CallStepTest.kt
@@ -20,7 +20,6 @@ import assertk.assertThat
 import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.internal.addPathSegment
 import com.pexip.sdk.infinity.CallId
 import com.pexip.sdk.infinity.ParticipantId

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/NodeResolverTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/NodeResolverTest.kt
@@ -19,7 +19,6 @@ package com.pexip.sdk.api.infinity
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import com.pexip.sdk.api.coroutines.await
 import kotlinx.coroutines.test.runTest
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ParticipantStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ParticipantStepTest.kt
@@ -20,7 +20,6 @@ import assertk.assertThat
 import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.internal.addPathSegment
 import com.pexip.sdk.infinity.ParticipantId
 import com.pexip.sdk.infinity.test.nextCallId

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/RegistrationStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/RegistrationStepTest.kt
@@ -20,7 +20,6 @@ import assertk.assertThat
 import assertk.assertions.hasMessage
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.infinity.test.nextRegistrationId
 import com.pexip.sdk.infinity.test.nextString
 import com.pexip.sdk.infinity.test.nextVersionId

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/RequestBuilderTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/RequestBuilderTest.kt
@@ -21,7 +21,6 @@ import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isInstanceOf
 import assertk.assertions.isTrue
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.infinity.Node
 import kotlinx.coroutines.test.runTest
 import okhttp3.HttpUrl

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
@@ -15,7 +15,6 @@
  */
 package com.pexip.sdk.conference.infinity
 
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.RequestTokenResponse
 import com.pexip.sdk.api.infinity.TokenStore

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/Events.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/Events.kt
@@ -15,7 +15,6 @@
  */
 package com.pexip.sdk.conference.infinity.internal
 
-import com.pexip.sdk.api.coroutines.asFlow
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.TokenStore
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImpl.kt
@@ -16,7 +16,6 @@
 package com.pexip.sdk.conference.infinity.internal
 
 import com.pexip.sdk.api.Event
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.AckRequest
 import com.pexip.sdk.api.infinity.CallsRequest
 import com.pexip.sdk.api.infinity.DtmfRequest

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/MessengerImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/MessengerImpl.kt
@@ -16,7 +16,6 @@
 package com.pexip.sdk.conference.infinity.internal
 
 import com.pexip.sdk.api.Event
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.MessageReceivedEvent
 import com.pexip.sdk.api.infinity.MessageRequest

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RefererImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RefererImpl.kt
@@ -15,7 +15,6 @@
  */
 package com.pexip.sdk.conference.infinity.internal
 
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.RequestTokenRequest
 import com.pexip.sdk.api.infinity.RequestTokenResponse

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RosterImpl.kt
@@ -17,7 +17,6 @@ package com.pexip.sdk.conference.infinity.internal
 
 import com.pexip.sdk.api.Call
 import com.pexip.sdk.api.Event
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.ConferenceUpdateEvent
 import com.pexip.sdk.api.infinity.InfinityService.ConferenceStep
 import com.pexip.sdk.api.infinity.InfinityService.ParticipantStep

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/ThemeImpl.kt
@@ -16,7 +16,6 @@
 package com.pexip.sdk.conference.infinity.internal
 
 import com.pexip.sdk.api.Event
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.ElementResponse
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.InvalidTokenException

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/TestCall.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/TestCall.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,22 @@ package com.pexip.sdk.conference.infinity.internal
 
 import com.pexip.sdk.api.Call
 import com.pexip.sdk.api.Callback
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 internal interface TestCall<T> : Call<T> {
+
+    override suspend fun await(): T = suspendCancellableCoroutine {
+        it.invokeOnCancellation { cancel() }
+        val callback = object : Callback<T> {
+
+            override fun onSuccess(call: Call<T>, response: T) = it.resume(response)
+
+            override fun onFailure(call: Call<T>, t: Throwable) = it.resumeWithException(t)
+        }
+        enqueue(callback)
+    }
 
     override fun execute(): T = TODO()
 

--- a/sdk-registration/src/main/kotlin/com/pexip/sdk/registration/infinity/InfinityRegistration.kt
+++ b/sdk-registration/src/main/kotlin/com/pexip/sdk/registration/infinity/InfinityRegistration.kt
@@ -15,7 +15,6 @@
  */
 package com.pexip.sdk.registration.infinity
 
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.RequestRegistrationTokenResponse
 import com.pexip.sdk.api.infinity.TokenStore

--- a/sdk-registration/src/main/kotlin/com/pexip/sdk/registration/infinity/internal/Events.kt
+++ b/sdk-registration/src/main/kotlin/com/pexip/sdk/registration/infinity/internal/Events.kt
@@ -15,7 +15,6 @@
  */
 package com.pexip.sdk.registration.infinity.internal
 
-import com.pexip.sdk.api.coroutines.asFlow
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.TokenStore
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/sdk-registration/src/main/kotlin/com/pexip/sdk/registration/infinity/internal/RegisteredDevicesFetcher.kt
+++ b/sdk-registration/src/main/kotlin/com/pexip/sdk/registration/infinity/internal/RegisteredDevicesFetcher.kt
@@ -15,7 +15,6 @@
  */
 package com.pexip.sdk.registration.infinity.internal
 
-import com.pexip.sdk.api.coroutines.await
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.RegistrationResponse
 import com.pexip.sdk.api.infinity.TokenStore

--- a/sdk-registration/src/test/kotlin/com/pexip/sdk/registration/infinity/internal/TestCall.kt
+++ b/sdk-registration/src/test/kotlin/com/pexip/sdk/registration/infinity/internal/TestCall.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,8 +17,22 @@ package com.pexip.sdk.registration.infinity.internal
 
 import com.pexip.sdk.api.Call
 import com.pexip.sdk.api.Callback
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 internal interface TestCall<T> : Call<T> {
+
+    override suspend fun await(): T = suspendCancellableCoroutine {
+        it.invokeOnCancellation { cancel() }
+        val callback = object : Callback<T> {
+
+            override fun onSuccess(call: Call<T>, response: T) = it.resume(response)
+
+            override fun onFailure(call: Call<T>, t: Throwable) = it.resumeWithException(t)
+        }
+        enqueue(callback)
+    }
 
     override fun execute(): T = TODO()
 


### PR DESCRIPTION
This is the first step in a series of PRs that see the deprecation (and
subsequent removal) of blocking and callback style access in `:sdk-api`.

The end goal is to have everything be suspending instead.
