### PR TITLE
feat(api,media): call disconnect when disposing MediaConnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- A `disconnect` signal to let Infinity know that the `MediaConnection` is going away
+
 ### Changed
 
 - Required JDK to 17

--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -579,6 +579,7 @@ public abstract interface class com/pexip/sdk/api/infinity/InfinityService {
 public abstract interface class com/pexip/sdk/api/infinity/InfinityService$CallStep {
 	public fun ack (Lcom/pexip/sdk/api/infinity/AckRequest;Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun ack (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
+	public fun disconnect (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun dtmf (Lcom/pexip/sdk/api/infinity/DtmfRequest;Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun getCallId-XxhQU_c ()Ljava/lang/String;
 	public fun getParticipantStep ()Lcom/pexip/sdk/api/infinity/InfinityService$ParticipantStep;

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
@@ -720,6 +720,16 @@ public interface InfinityService {
          */
         public fun dtmf(request: DtmfRequest, token: Token): Call<Boolean> =
             throw NotImplementedError()
+
+        /**
+         * Disconnects the call.
+         *
+         * See [documentation](https://docs.pexip.com/api_client/api_rest.htm#call_disconnect).
+         *
+         * @param token a valid token
+         * @return true if successful, false otherwise
+         */
+        public fun disconnect(token: Token): Call<Boolean> = throw NotImplementedError()
     }
 
     public companion object {

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImpl.kt
@@ -129,6 +129,11 @@ internal class MediaConnectionSignalingImpl(
         retry { callStep.newCandidate(request, store.token.value).await() }
     }
 
+    override suspend fun onDisconnect() {
+        val callStep = callStep.await()
+        retry { callStep.disconnect(store.token.value).await() }
+    }
+
     override suspend fun onDtmf(digits: String) {
         val callStep = callStep.await()
         val request = DtmfRequest(digits)

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/MediaConnectionSignalingImplTest.kt
@@ -543,6 +543,31 @@ internal class MediaConnectionSignalingImplTest {
     }
 
     @Test
+    fun `onDisconnect() returns`() = runTest {
+        val called = Job()
+        val result = Random.nextBoolean()
+        val signaling = MediaConnectionSignalingImpl(
+            scope = backgroundScope,
+            event = event,
+            store = store,
+            participantStep = object : InfinityService.ParticipantStep {},
+            versionId = versionId,
+            directMedia = Random.nextBoolean(),
+            iceServers = iceServers,
+            callStep = object : InfinityService.CallStep {
+                override fun disconnect(token: Token): Call<Boolean> = call {
+                    called.complete()
+                    result
+                }
+            },
+            iceTransportsRelayOnly = Random.nextBoolean(),
+            dataChannel = null,
+        )
+        signaling.onDisconnect()
+        called.join()
+    }
+
+    @Test
     fun `onAudioMuted() returns`() = runTest {
         val called = Job()
         val signaling = MediaConnectionSignalingImpl(

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
@@ -468,6 +468,7 @@ internal class WebRtcMediaConnection(
                 mainRemoteVideoTrackListeners.clear()
                 presentationRemoteVideoTrackListeners.clear()
                 wrapper.dispose()
+                runCatching { config.signaling.onDisconnect() }
             }
         }
     }

--- a/sdk-media/api/sdk-media.api
+++ b/sdk-media/api/sdk-media.api
@@ -242,6 +242,7 @@ public abstract interface class com/pexip/sdk/media/MediaConnectionSignaling {
 	public abstract fun onAudioUnmuted (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onCandidate (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onData (Lcom/pexip/sdk/media/Data;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onDisconnect (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onDtmf (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onOffer (Ljava/lang/String;Ljava/lang/String;ZZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onOfferIgnored (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/sdk-media/src/main/kotlin/com/pexip/sdk/media/MediaConnectionSignaling.kt
+++ b/sdk-media/src/main/kotlin/com/pexip/sdk/media/MediaConnectionSignaling.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -80,6 +80,11 @@ public interface MediaConnectionSignaling {
      * @param pwd a password of this ICE candidate
      */
     public suspend fun onCandidate(candidate: String, mid: String, ufrag: String, pwd: String)
+
+    /**
+     * Invoked when the [MediaConnection] is disposed.
+     */
+    public suspend fun onDisconnect()
 
     /**
      * Invoked when a sequence of DTMF digits must be sent.


### PR DESCRIPTION
This is likely to result in 403 since we may release the token around the
same time in a normal call, but it is important for breakout rooms where
the token may live longer than an individual `MediaConnection`.
