### PR TITLE
feat(api): add ConferenceStep.conference()

### DIFF
--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="KotlinJpsPluginSettings">
-    <option name="version" value="2.0.20" />
+    <option name="version" value="2.0.21" />
   </component>
 </project>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 
 - A `disconnect` signal to let Infinity know that the `MediaConnection` is going away
+- `ConferenceStep.conference(String)` to create a new `ConferenceStep` using a different alias
 
 ### Changed
 

--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -601,6 +601,7 @@ public abstract interface class com/pexip/sdk/api/infinity/InfinityService$Confe
 	public fun availableLayouts (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun breakout-CBrjPA4 (Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/InfinityService$BreakoutStep;
 	public fun clearAllBuzz (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
+	public fun conference (Ljava/lang/String;)Lcom/pexip/sdk/api/infinity/InfinityService$ConferenceStep;
 	public fun disconnect (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/Call;
 	public fun events (Lcom/pexip/sdk/api/infinity/Token;)Lcom/pexip/sdk/api/EventSourceFactory;
 	public fun getConferenceAlias ()Ljava/lang/String;

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
@@ -328,6 +328,13 @@ public interface InfinityService {
         public fun events(token: Token): EventSourceFactory = throw NotImplementedError()
 
         /**
+         * Sets the conference alias.
+         *
+         * @param conferenceAlias a conference alias
+         */
+        public fun conference(conferenceAlias: String): ConferenceStep = throw NotImplementedError()
+
+        /**
          * Sets the breakout ID.
          *
          * @param breakoutId an ID of the breakout

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
@@ -289,6 +289,11 @@ internal class ConferenceStepImpl(
         json = json,
     )
 
+    override fun conference(conferenceAlias: String): InfinityService.ConferenceStep {
+        require(conferenceAlias.isNotBlank()) { "conferenceAlias is blank." }
+        return ConferenceStepImpl(requestBuilder, conferenceAlias)
+    }
+
     override fun breakout(breakoutId: BreakoutId): InfinityService.BreakoutStep =
         BreakoutStepImpl(breakoutId, this)
 

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/ConferenceStepTest.kt
@@ -23,6 +23,7 @@ import assertk.assertions.hasMessage
 import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEqualTo
 import assertk.assertions.prop
 import assertk.tableOf
 import com.pexip.sdk.api.infinity.internal.RequiredPinResponse
@@ -79,6 +80,15 @@ internal class ConferenceStepTest {
     @Test
     fun `conferenceAlias returns the correct value`() {
         assertThat(step::conferenceAlias).isEqualTo(conferenceAlias)
+    }
+
+    @Test
+    fun `conference returns a new ConferenceStep`() {
+        val conferenceAlias = Random.nextString()
+        assertThat(step.conference(conferenceAlias)).all {
+            isNotEqualTo(step)
+            prop(InfinityService.ConferenceStep::conferenceAlias).isEqualTo(conferenceAlias)
+        }
     }
 
     @Test

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
@@ -100,7 +100,7 @@ public class InfinityConference private constructor(
     )
 
     override val referer: Referer = RefererImpl(
-        builder = step.requestBuilder,
+        step = step,
         callTag = response.callTag,
         directMedia = response.directMediaRequested,
     )

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RefererImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/RefererImpl.kt
@@ -27,25 +27,25 @@ import com.pexip.sdk.core.retry
 import kotlinx.coroutines.CancellationException
 
 internal class RefererImpl(
-    private val builder: InfinityService.RequestBuilder,
+    private val step: InfinityService.ConferenceStep,
     private val callTag: String,
     private val directMedia: Boolean,
     private val createConference: (InfinityService.ConferenceStep, RequestTokenResponse) -> Conference,
 ) : Referer {
 
     constructor(
-        builder: InfinityService.RequestBuilder,
+        step: InfinityService.ConferenceStep,
         callTag: String,
         directMedia: Boolean,
     ) : this(
-        builder = builder,
+        step = step,
         callTag = callTag,
         directMedia = directMedia,
         createConference = InfinityConference::create,
     )
 
     override suspend fun refer(event: ReferConferenceEvent): Conference = try {
-        val step = builder.conference(event.conferenceAlias)
+        val step = step.conference(event.conferenceAlias)
         val request = RequestTokenRequest(
             incomingToken = event.token,
             directMedia = directMedia,

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RefererTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/RefererTest.kt
@@ -67,20 +67,18 @@ class RefererTest {
         val directMedia = Random.nextBoolean()
         val step = object : InfinityService.ConferenceStep {
 
+            override fun conference(conferenceAlias: String): InfinityService.ConferenceStep {
+                assertThat(conferenceAlias, "conferenceAlias").isEqualTo(event.conferenceAlias)
+                return this
+            }
+
             override fun requestToken(request: RequestTokenRequest): Call<RequestTokenResponse> {
                 assertThat(request::incomingToken).isEqualTo(event.token)
                 assertThat(request::directMedia).isEqualTo(directMedia)
                 return call { throw t }
             }
         }
-        val builder = object : InfinityService.RequestBuilder {
-
-            override fun conference(conferenceAlias: String): InfinityService.ConferenceStep {
-                assertThat(conferenceAlias, "conferenceAlias").isEqualTo(event.conferenceAlias)
-                return step
-            }
-        }
-        val referer = RefererImpl(builder, callTag, directMedia, ::TestConference)
+        val referer = RefererImpl(step, callTag, directMedia, ::TestConference)
         assertFailure { referer.refer(event) }
             .isInstanceOf<ReferException>()
             .hasCause(t)
@@ -103,6 +101,11 @@ class RefererTest {
         )
         val step = object : InfinityService.ConferenceStep {
 
+            override fun conference(conferenceAlias: String): InfinityService.ConferenceStep {
+                assertThat(conferenceAlias, "conferenceAlias").isEqualTo(event.conferenceAlias)
+                return this
+            }
+
             override fun requestToken(request: RequestTokenRequest): Call<RequestTokenResponse> {
                 assertThat(request::incomingToken).isEqualTo(event.token)
                 assertThat(request::directMedia).isEqualTo(response.directMediaRequested)
@@ -110,14 +113,7 @@ class RefererTest {
                 return call { response }
             }
         }
-        val builder = object : InfinityService.RequestBuilder {
-
-            override fun conference(conferenceAlias: String): InfinityService.ConferenceStep {
-                assertThat(conferenceAlias, "conferenceAlias").isEqualTo(event.conferenceAlias)
-                return step
-            }
-        }
-        val referer = RefererImpl(builder, callTag, response.directMediaRequested, ::TestConference)
+        val referer = RefererImpl(step, callTag, response.directMediaRequested, ::TestConference)
         assertThat(referer.refer(event), "conference").isEqualTo(TestConference(step, response))
     }
 


### PR DESCRIPTION
This is a direct replacement for `ConferenceStep.requestBuilder.conference()`.
