### PR TITLE
refactor(api): deprecate some InfinityService properties

### DIFF
--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
@@ -64,6 +64,7 @@ public interface InfinityService {
         /**
          * The Infinity service that produced this request builder.
          */
+        @Deprecated("Deprecated without a replacement.")
         public val infinityService: InfinityService
             get() = throw NotImplementedError()
 
@@ -106,6 +107,7 @@ public interface InfinityService {
         /**
          * The request builder that produced this conference step.
          */
+        @Deprecated("Deprecated without a replacement.")
         public val requestBuilder: RequestBuilder
             get() = throw NotImplementedError()
 
@@ -363,6 +365,7 @@ public interface InfinityService {
         /**
          * The request builder that produced this registration step.
          */
+        @Deprecated("Deprecated without a replacement.")
         public val requestBuilder: RequestBuilder
             get() = throw NotImplementedError()
 
@@ -448,6 +451,7 @@ public interface InfinityService {
         /**
          * The conference step that produced this participant step.
          */
+        @Deprecated("Deprecated without a replacement.")
         public val conferenceStep: ConferenceStep
             get() = throw NotImplementedError()
 
@@ -667,6 +671,7 @@ public interface InfinityService {
         /**
          * The participant step that produced this call step.
          */
+        @Deprecated("Deprecated without a replacement.")
         public val participantStep: ParticipantStep
             get() = throw NotImplementedError()
 


### PR DESCRIPTION
These properties returned the previous "step" object, but to be able to
reuse some for breakouts we'll have to remove these properties.
