### PR TITLE
feat(media): use software ns and aec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Required JDK to 17
 - Microphone mute to rely on `AudioDeviceModule.setMicrophoneMute(Boolean)` instead of
   `AudioManager.setMicrophoneMute(Boolean)`
+- Noise suppressor and acoustic echo canceler to use software implementation
 
 ## [0.16.0] - 2024-10-02
 

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/WebRtcMediaConnectionFactory.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/WebRtcMediaConnectionFactory.kt
@@ -388,6 +388,8 @@ public class WebRtcMediaConnectionFactory private constructor(
                 .setAudioAttributes(audioAttributes)
                 .setAudioTrackStateCallback(audioTrackStateCallback)
                 .setAudioRecordStateCallback(audioRecordStateCallback)
+                .setUseHardwareNoiseSuppressor(false)
+                .setUseHardwareAcousticEchoCanceler(false)
                 .createAudioDeviceModule()
         }
 


### PR DESCRIPTION
There has been a number of reports of hardware NS and AEC not working on
a range of devices.

Instead, we'll use software NS and AEC provided by WebRTC and consumers
can customize this behavior by providing a custom `AudioDeviceModule` if
they wish to use hardware implementation.
