### PR TITLE
feat(conference): add Breakout and Breakouts

### DIFF
--- a/sdk-conference/api/sdk-conference.api
+++ b/sdk-conference/api/sdk-conference.api
@@ -10,6 +10,15 @@ public final class com/pexip/sdk/conference/AllowGuestsToUnmuteException : java/
 	public synthetic fun <init> (Ljava/lang/Throwable;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
+public abstract interface class com/pexip/sdk/conference/Breakout {
+	public abstract fun getId-Yx3DcQY ()Ljava/lang/String;
+	public abstract fun getParticipantId-UyOe1Tk ()Ljava/lang/String;
+}
+
+public abstract interface class com/pexip/sdk/conference/Breakouts {
+	public abstract fun getBreakouts ()Lkotlinx/coroutines/flow/StateFlow;
+}
+
 public final class com/pexip/sdk/conference/ClientMuteException : java/lang/RuntimeException {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/Throwable;)V
@@ -23,6 +32,7 @@ public final class com/pexip/sdk/conference/ClientUnmuteException : java/lang/Ru
 }
 
 public abstract interface class com/pexip/sdk/conference/Conference {
+	public fun getBreakouts ()Lcom/pexip/sdk/conference/Breakouts;
 	public abstract fun getMessenger ()Lcom/pexip/sdk/conference/Messenger;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun getReferer ()Lcom/pexip/sdk/conference/Referer;
@@ -453,6 +463,7 @@ public final class com/pexip/sdk/conference/infinity/InfinityConference : com/pe
 	public synthetic fun <init> (Lcom/pexip/sdk/api/infinity/InfinityService$ConferenceStep;Lcom/pexip/sdk/api/infinity/RequestTokenResponse;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public static final fun create (Lcom/pexip/sdk/api/infinity/InfinityService$ConferenceStep;Lcom/pexip/sdk/api/infinity/RequestTokenResponse;)Lcom/pexip/sdk/conference/infinity/InfinityConference;
 	public static final fun create (Lcom/pexip/sdk/api/infinity/InfinityService;Ljava/net/URL;Ljava/lang/String;Lcom/pexip/sdk/api/infinity/RequestTokenResponse;)Lcom/pexip/sdk/conference/infinity/InfinityConference;
+	public fun getBreakouts ()Lcom/pexip/sdk/conference/Breakouts;
 	public fun getMessenger ()Lcom/pexip/sdk/conference/Messenger;
 	public fun getName ()Ljava/lang/String;
 	public fun getReferer ()Lcom/pexip/sdk/conference/Referer;

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Breakout.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Breakout.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.conference
+
+import com.pexip.sdk.infinity.BreakoutId
+import com.pexip.sdk.infinity.ParticipantId
+
+/**
+ * A breakout in a conference.
+ */
+public interface Breakout {
+
+    /**
+     * A unique ID of this breakout.
+     */
+    public val id: BreakoutId
+
+    /**
+     * A unique participant ID assigned to you in this breakout.
+     */
+    public val participantId: ParticipantId
+}

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Breakouts.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Breakouts.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.conference
+
+import com.pexip.sdk.infinity.BreakoutId
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * Handles conference breakouts.
+ */
+public interface Breakouts {
+
+    /**
+     * A [StateFlow] that represents breakouts in this conference.
+     */
+    public val breakouts: StateFlow<Map<BreakoutId, Breakout>>
+}

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Conference.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/Conference.kt
@@ -29,6 +29,7 @@ import com.pexip.sdk.media.MediaConnectionSignaling
  * @property roster an instance of [Roster] attached to this [Conference]
  * @property referer an instance of [Referer] attached to this [Conference]
  * @property messenger an instance of [Messenger] attached to this [Conference]
+ * @property breakouts an instance of [Breakouts] attached to this [Conference]
  * @property signaling an instance of [MediaConnectionSignaling] to be used with [MediaConnection]
  */
 public interface Conference {
@@ -45,6 +46,8 @@ public interface Conference {
     public val referer: Referer
 
     public val messenger: Messenger
+
+    public val breakouts: Breakouts get() = throw NotImplementedError()
 
     public val serviceType: ServiceType
 

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/InfinityConference.kt
@@ -18,6 +18,7 @@ package com.pexip.sdk.conference.infinity
 import com.pexip.sdk.api.infinity.InfinityService
 import com.pexip.sdk.api.infinity.RequestTokenResponse
 import com.pexip.sdk.api.infinity.TokenStore
+import com.pexip.sdk.conference.Breakouts
 import com.pexip.sdk.conference.Conference
 import com.pexip.sdk.conference.ConferenceEvent
 import com.pexip.sdk.conference.ConferenceEventListener
@@ -25,6 +26,7 @@ import com.pexip.sdk.conference.Messenger
 import com.pexip.sdk.conference.Referer
 import com.pexip.sdk.conference.Roster
 import com.pexip.sdk.conference.Theme
+import com.pexip.sdk.conference.infinity.internal.BreakoutsImpl
 import com.pexip.sdk.conference.infinity.internal.ConferenceEvent
 import com.pexip.sdk.conference.infinity.internal.DataChannelImpl
 import com.pexip.sdk.conference.infinity.internal.DataChannelMessengerImpl
@@ -145,6 +147,8 @@ public class InfinityConference private constructor(
         )
     }
 
+    override val breakouts: Breakouts = BreakoutsImpl(scope, event)
+
     init {
         store.refreshTokenIn(
             scope = scope,
@@ -192,7 +196,9 @@ public class InfinityConference private constructor(
         @Suppress("UNUSED_PARAMETER")
         @Deprecated(
             message = "Use a version of this method that accepts ConferenceStep",
-            replaceWith = ReplaceWith("create(service.newRequest(node).conference(conferenceAlias)), response)"),
+            replaceWith = ReplaceWith(
+                "create(service.newRequest(node).conference(conferenceAlias)), response)",
+            ),
             level = DeprecationLevel.ERROR,
         )
         @JvmStatic

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/BreakoutImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/BreakoutImpl.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.conference.infinity.internal
+
+import com.pexip.sdk.conference.Breakout
+import com.pexip.sdk.infinity.BreakoutId
+import com.pexip.sdk.infinity.ParticipantId
+
+internal data class BreakoutImpl(
+    override val id: BreakoutId,
+    override val participantId: ParticipantId,
+) : Breakout

--- a/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/BreakoutsImpl.kt
+++ b/sdk-conference/src/main/kotlin/com/pexip/sdk/conference/infinity/internal/BreakoutsImpl.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.conference.infinity.internal
+
+import com.pexip.sdk.api.Event
+import com.pexip.sdk.api.infinity.BreakoutBeginEvent
+import com.pexip.sdk.api.infinity.BreakoutEndEvent
+import com.pexip.sdk.conference.Breakout
+import com.pexip.sdk.conference.Breakouts
+import com.pexip.sdk.infinity.BreakoutId
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.stateIn
+
+internal class BreakoutsImpl(scope: CoroutineScope, event: Flow<Event>) : Breakouts {
+
+    override val breakouts: StateFlow<Map<BreakoutId, Breakout>> = channelFlow {
+        val map = mutableMapOf<BreakoutId, Breakout>()
+        event.collect {
+            when (it) {
+                is BreakoutBeginEvent -> {
+                    map[it.id] = BreakoutImpl(it.id, it.participantId)
+                    send(map.toMap())
+                }
+                is BreakoutEndEvent -> {
+                    map -= it.id
+                    send(map.toMap())
+                }
+                else -> Unit
+            }
+        }
+    }.stateIn(scope, SharingStarted.Eagerly, emptyMap())
+}

--- a/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/BreakoutsImplTest.kt
+++ b/sdk-conference/src/test/kotlin/com/pexip/sdk/conference/infinity/internal/BreakoutsImplTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.conference.infinity.internal
+
+import app.cash.turbine.test
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEmpty
+import assertk.assertions.isEqualTo
+import assertk.assertions.key
+import assertk.assertions.prop
+import com.pexip.sdk.api.Event
+import com.pexip.sdk.api.infinity.BreakoutBeginEvent
+import com.pexip.sdk.api.infinity.BreakoutEndEvent
+import com.pexip.sdk.conference.Breakout
+import com.pexip.sdk.infinity.test.nextBreakoutId
+import com.pexip.sdk.infinity.test.nextParticipantId
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.random.Random
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class BreakoutsImplTest {
+
+    private lateinit var event: MutableSharedFlow<Event>
+
+    @BeforeTest
+    fun setUp() {
+        event = MutableSharedFlow(extraBufferCapacity = 1)
+    }
+
+    @Test
+    fun `breakout_begin and breakout_end correctly modify the collection`() = runTest {
+        val breakouts = BreakoutsImpl(backgroundScope, event)
+        breakouts.breakouts.test {
+            event.subscriptionCount.first { it > 0 }
+            assertThat(awaitItem(), "breakouts").isEmpty()
+            val breakoutBeginEvent = BreakoutBeginEvent(
+                id = Random.nextBreakoutId(),
+                participantId = Random.nextParticipantId(),
+            )
+            event.emit(breakoutBeginEvent)
+            assertThat(awaitItem(), "breakouts").key(breakoutBeginEvent.id).all {
+                prop(Breakout::id).isEqualTo(breakoutBeginEvent.id)
+                prop(Breakout::participantId).isEqualTo(breakoutBeginEvent.participantId)
+            }
+            val missingBreakoutEndEvent = BreakoutEndEvent(
+                id = Random.nextBreakoutId(),
+                participantId = Random.nextParticipantId(),
+            )
+            event.emit(missingBreakoutEndEvent)
+            expectNoEvents()
+            val breakoutEndEvent = BreakoutEndEvent(
+                id = breakoutBeginEvent.id,
+                participantId = breakoutBeginEvent.participantId,
+            )
+            event.emit(breakoutEndEvent)
+            assertThat(awaitItem(), "breakouts").isEmpty()
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a few new classes and observes any relevant
`breakout_begin` & `breakout_end` events to manage active breakouts.
