### PR TITLE
refactor(api): switch to polymorphic serialization for Event

### DIFF
--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -91,7 +91,7 @@ public final class com/pexip/sdk/api/infinity/BackgroundResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/BreakoutBeginEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/BreakoutBeginEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/BreakoutBeginEvent$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-Yx3DcQY ()Ljava/lang/String;
@@ -120,7 +120,7 @@ public final class com/pexip/sdk/api/infinity/BreakoutBeginEvent$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/BreakoutEndEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/BreakoutEndEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/BreakoutEndEvent$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-Yx3DcQY ()Ljava/lang/String;
@@ -149,10 +149,11 @@ public final class com/pexip/sdk/api/infinity/BreakoutEndEvent$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/ByeEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/ByeEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field INSTANCE Lcom/pexip/sdk/api/infinity/ByeEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -222,7 +223,7 @@ public final class com/pexip/sdk/api/infinity/CallsResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/ConferenceUpdateEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/ConferenceUpdateEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/ConferenceUpdateEvent$Companion;
 	public fun <init> ()V
 	public fun <init> (ZZZZLjava/lang/Boolean;)V
@@ -339,7 +340,7 @@ public final class com/pexip/sdk/api/infinity/DataChannelMessage$Unknown : com/p
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/pexip/sdk/api/infinity/DisconnectEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/DisconnectEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/DisconnectEvent$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -454,7 +455,7 @@ public final class com/pexip/sdk/api/infinity/FeccAction$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/FeccEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/FeccEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/FeccEvent$Companion;
 	public synthetic fun <init> (Lcom/pexip/sdk/api/infinity/FeccAction;JLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lcom/pexip/sdk/api/infinity/FeccAction;JLjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -568,7 +569,7 @@ public final class com/pexip/sdk/api/infinity/IllegalLayoutTransformException : 
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public final class com/pexip/sdk/api/infinity/IncomingCancelledEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/IncomingCancelledEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/IncomingCancelledEvent$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -595,7 +596,7 @@ public final class com/pexip/sdk/api/infinity/IncomingCancelledEvent$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/IncomingEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/IncomingEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/IncomingEvent$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -623,6 +624,14 @@ public synthetic class com/pexip/sdk/api/infinity/IncomingEvent$$serializer : ko
 }
 
 public final class com/pexip/sdk/api/infinity/IncomingEvent$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public abstract interface class com/pexip/sdk/api/infinity/InfinityEvent : com/pexip/sdk/api/Event {
+	public static final field Companion Lcom/pexip/sdk/api/infinity/InfinityEvent$Companion;
+}
+
+public final class com/pexip/sdk/api/infinity/InfinityEvent$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
@@ -737,7 +746,7 @@ public final class com/pexip/sdk/api/infinity/InvalidTokenException : java/lang/
 	public synthetic fun <init> (Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
-public final class com/pexip/sdk/api/infinity/LayoutEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/LayoutEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/LayoutEvent$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lcom/pexip/sdk/api/infinity/RequestedLayout;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Lcom/pexip/sdk/api/infinity/RequestedLayout;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -769,7 +778,7 @@ public final class com/pexip/sdk/api/infinity/LayoutEvent$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/MessageReceivedEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/MessageReceivedEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/MessageReceivedEvent$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -834,7 +843,7 @@ public final class com/pexip/sdk/api/infinity/MessageRequest$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/NewCandidateEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/NewCandidateEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/NewCandidateEvent$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -902,7 +911,7 @@ public final class com/pexip/sdk/api/infinity/NewCandidateRequest$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/NewOfferEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/NewOfferEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/NewOfferEvent$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -965,7 +974,7 @@ public abstract interface class com/pexip/sdk/api/infinity/OfferResponse {
 	public abstract fun getSdp ()Ljava/lang/String;
 }
 
-public final class com/pexip/sdk/api/infinity/ParticipantCreateEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/ParticipantCreateEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/ParticipantCreateEvent$Companion;
 	public static final synthetic fun box-impl (Lcom/pexip/sdk/api/infinity/ParticipantResponse;)Lcom/pexip/sdk/api/infinity/ParticipantCreateEvent;
 	public static fun constructor-impl (Lcom/pexip/sdk/api/infinity/ParticipantResponse;)Lcom/pexip/sdk/api/infinity/ParticipantResponse;
@@ -995,7 +1004,7 @@ public final class com/pexip/sdk/api/infinity/ParticipantCreateEvent$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/ParticipantDeleteEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/ParticipantDeleteEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/ParticipantDeleteEvent$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-UyOe1Tk ()Ljava/lang/String;
@@ -1080,21 +1089,23 @@ public final class com/pexip/sdk/api/infinity/ParticipantResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/ParticipantSyncBeginEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/ParticipantSyncBeginEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field INSTANCE Lcom/pexip/sdk/api/infinity/ParticipantSyncBeginEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/pexip/sdk/api/infinity/ParticipantSyncEndEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/ParticipantSyncEndEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field INSTANCE Lcom/pexip/sdk/api/infinity/ParticipantSyncEndEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/pexip/sdk/api/infinity/ParticipantUpdateEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/ParticipantUpdateEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/ParticipantUpdateEvent$Companion;
 	public static final synthetic fun box-impl (Lcom/pexip/sdk/api/infinity/ParticipantResponse;)Lcom/pexip/sdk/api/infinity/ParticipantUpdateEvent;
 	public static fun constructor-impl (Lcom/pexip/sdk/api/infinity/ParticipantResponse;)Lcom/pexip/sdk/api/infinity/ParticipantResponse;
@@ -1124,7 +1135,7 @@ public final class com/pexip/sdk/api/infinity/ParticipantUpdateEvent$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/PeerDisconnectEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/PeerDisconnectEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field INSTANCE Lcom/pexip/sdk/api/infinity/PeerDisconnectEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
@@ -1159,7 +1170,7 @@ public final class com/pexip/sdk/api/infinity/PreferredAspectRatioRequest$Compan
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/PresentationStartEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/PresentationStartEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/PresentationStartEvent$Companion;
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -1188,14 +1199,15 @@ public final class com/pexip/sdk/api/infinity/PresentationStartEvent$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/PresentationStopEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/PresentationStopEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field INSTANCE Lcom/pexip/sdk/api/infinity/PresentationStopEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/pexip/sdk/api/infinity/ReferEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/ReferEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/ReferEvent$Companion;
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
@@ -1607,7 +1619,7 @@ public final class com/pexip/sdk/api/infinity/SpeakerResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/SplashScreenEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/SplashScreenEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/SplashScreenEvent$Companion;
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;)V
@@ -1671,30 +1683,27 @@ public final class com/pexip/sdk/api/infinity/SsoRedirectException : java/lang/R
 	public final fun getUrl ()Ljava/lang/String;
 }
 
-public final class com/pexip/sdk/api/infinity/StageEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/StageEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/StageEvent$Companion;
-	public static final synthetic fun box-impl (Ljava/util/List;)Lcom/pexip/sdk/api/infinity/StageEvent;
-	public static fun constructor-impl (Ljava/util/List;)Ljava/util/List;
-	public static fun constructor-impl ([Lcom/pexip/sdk/api/infinity/SpeakerResponse;)Ljava/util/List;
+	public fun <init> (Ljava/util/List;)V
+	public fun <init> ([Lcom/pexip/sdk/api/infinity/SpeakerResponse;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Lcom/pexip/sdk/api/infinity/StageEvent;
+	public static synthetic fun copy$default (Lcom/pexip/sdk/api/infinity/StageEvent;Ljava/util/List;ILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/StageEvent;
 	public fun equals (Ljava/lang/Object;)Z
-	public static fun equals-impl (Ljava/util/List;Ljava/lang/Object;)Z
-	public static final fun equals-impl0 (Ljava/util/List;Ljava/util/List;)Z
 	public final fun getSpeakers ()Ljava/util/List;
 	public fun hashCode ()I
-	public static fun hashCode-impl (Ljava/util/List;)I
 	public fun toString ()Ljava/lang/String;
-	public static fun toString-impl (Ljava/util/List;)Ljava/lang/String;
-	public final synthetic fun unbox-impl ()Ljava/util/List;
 }
 
 public synthetic class com/pexip/sdk/api/infinity/StageEvent$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
 	public static final field INSTANCE Lcom/pexip/sdk/api/infinity/StageEvent$$serializer;
 	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Lcom/pexip/sdk/api/infinity/StageEvent;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
-	public final fun deserialize-y93Zkrk (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/List;
 	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Lcom/pexip/sdk/api/infinity/StageEvent;)V
 	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
-	public final fun serialize-5rI60R0 (Lkotlinx/serialization/encoding/Encoder;Ljava/util/List;)V
 	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
 }
 
@@ -1803,6 +1812,14 @@ public final class com/pexip/sdk/api/infinity/TurnResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
+public final class com/pexip/sdk/api/infinity/UnknownEvent : com/pexip/sdk/api/infinity/InfinityEvent {
+	public static final field INSTANCE Lcom/pexip/sdk/api/infinity/UnknownEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class com/pexip/sdk/api/infinity/UpdateRequest {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/UpdateRequest$Companion;
 	public fun <init> (Ljava/lang/String;Z)V
@@ -1864,7 +1881,7 @@ public final class com/pexip/sdk/api/infinity/UpdateResponse$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
-public final class com/pexip/sdk/api/infinity/UpdateSdpEvent : com/pexip/sdk/api/Event {
+public final class com/pexip/sdk/api/infinity/UpdateSdpEvent : com/pexip/sdk/api/infinity/InfinityEvent {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/UpdateSdpEvent$Companion;
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/InfinityService.kt
@@ -773,6 +773,9 @@ public interface InfinityService {
             ignoreUnknownKeys = true
             coerceInputValues = true
             serializersModule = SerializersModule {
+                polymorphicDefaultDeserializer(InfinityEvent::class) {
+                    UnknownEvent.serializer()
+                }
                 polymorphicDefaultDeserializer(ElementResponse::class) {
                     ElementResponse.Unknown.serializer()
                 }

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/ConferenceStepImpl.kt
@@ -286,7 +286,6 @@ internal class ConferenceStepImpl(
             }
             .token(token)
             .build(),
-        json = json,
     )
 
     override fun conference(conferenceAlias: String): InfinityService.ConferenceStep {

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RealEventSource.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RealEventSource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,13 @@ package com.pexip.sdk.api.infinity.internal
 
 import com.pexip.sdk.api.EventSource
 import com.pexip.sdk.api.EventSourceListener
-import com.pexip.sdk.api.infinity.Event
-import kotlinx.serialization.json.Json
+import com.pexip.sdk.api.infinity.InfinityEvent
+import com.pexip.sdk.api.infinity.UnknownEvent
 import okhttp3.Response
 
 internal class RealEventSource(
     factory: okhttp3.sse.EventSource.Factory,
     request: okhttp3.Request,
-    json: Json,
     listener: EventSourceListener,
 ) : EventSource {
 
@@ -40,7 +39,8 @@ internal class RealEventSource(
             type: String?,
             data: String,
         ) {
-            val event = Event(json, id, type, data) ?: return
+            val event = InfinityEvent(id, type, data)
+            if (event is UnknownEvent) return
             listener.onEvent(this@RealEventSource, event)
         }
 
@@ -58,7 +58,5 @@ internal class RealEventSource(
     }
     private val source = factory.newEventSource(request, l)
 
-    override fun cancel() {
-        source.cancel()
-    }
+    override fun cancel() = source.cancel()
 }

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RealEventSourceFactory.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RealEventSourceFactory.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2023 Pexip AS
+ * Copyright 2022-2024 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,20 +18,16 @@ package com.pexip.sdk.api.infinity.internal
 import com.pexip.sdk.api.EventSource
 import com.pexip.sdk.api.EventSourceFactory
 import com.pexip.sdk.api.EventSourceListener
-import kotlinx.serialization.json.Json
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.sse.EventSources
 import java.util.concurrent.TimeUnit
 
-internal class RealEventSourceFactory(
-    client: OkHttpClient,
-    private val request: Request,
-    private val json: Json,
-) : EventSourceFactory {
+internal class RealEventSourceFactory(client: OkHttpClient, private val request: Request) :
+    EventSourceFactory {
 
     private val factory = EventSources.createFactory(client) { readTimeout(0, TimeUnit.SECONDS) }
 
     override fun create(listener: EventSourceListener): EventSource =
-        RealEventSource(factory, request, json, listener)
+        RealEventSource(factory, request, listener)
 }

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RegistrationStepImpl.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/internal/RegistrationStepImpl.kt
@@ -34,7 +34,8 @@ import okio.ByteString.Companion.encodeUtf8
 internal class RegistrationStepImpl(
     override val requestBuilder: RequestBuilderImpl,
     override val deviceAlias: String,
-) : InfinityService.RegistrationStep, RequestBuilderImplScope by requestBuilder {
+) : InfinityService.RegistrationStep,
+    RequestBuilderImplScope by requestBuilder {
 
     override fun requestToken(
         username: String,
@@ -93,7 +94,6 @@ internal class RegistrationStepImpl(
             }
             .token(token)
             .build(),
-        json = json,
     )
 
     override fun registrations(token: Token, query: String): Call<List<RegistrationResponse>> =
@@ -150,9 +150,7 @@ internal class RegistrationStepImpl(
         else -> throw IllegalStateException()
     }
 
-    private fun Response.parse401(): Nothing {
-        throw NoSuchRegistrationException(body?.string())
-    }
+    private fun Response.parse401(): Nothing = throw NoSuchRegistrationException(body?.string())
 
     private fun Response.parse403(): Nothing {
         val message = json.decodeFromResponseBody(StringSerializer, body!!)

--- a/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/InfinityEventTest.kt
+++ b/sdk-api/src/test/kotlin/com/pexip/sdk/api/infinity/internal/InfinityEventTest.kt
@@ -17,7 +17,6 @@ package com.pexip.sdk.api.infinity.internal
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import assertk.assertions.isNull
 import assertk.tableOf
 import com.pexip.sdk.api.Event
 import com.pexip.sdk.api.infinity.BreakoutBeginEvent
@@ -25,13 +24,12 @@ import com.pexip.sdk.api.infinity.BreakoutEndEvent
 import com.pexip.sdk.api.infinity.ByeEvent
 import com.pexip.sdk.api.infinity.ConferenceUpdateEvent
 import com.pexip.sdk.api.infinity.DisconnectEvent
-import com.pexip.sdk.api.infinity.Event
 import com.pexip.sdk.api.infinity.FeccAction
 import com.pexip.sdk.api.infinity.FeccEvent
 import com.pexip.sdk.api.infinity.FeccMovement
 import com.pexip.sdk.api.infinity.IncomingCancelledEvent
 import com.pexip.sdk.api.infinity.IncomingEvent
-import com.pexip.sdk.api.infinity.InfinityService
+import com.pexip.sdk.api.infinity.InfinityEvent
 import com.pexip.sdk.api.infinity.LayoutEvent
 import com.pexip.sdk.api.infinity.MessageReceivedEvent
 import com.pexip.sdk.api.infinity.NewCandidateEvent
@@ -51,6 +49,7 @@ import com.pexip.sdk.api.infinity.Screen
 import com.pexip.sdk.api.infinity.SpeakerResponse
 import com.pexip.sdk.api.infinity.SplashScreenEvent
 import com.pexip.sdk.api.infinity.StageEvent
+import com.pexip.sdk.api.infinity.UnknownEvent
 import com.pexip.sdk.api.infinity.UpdateSdpEvent
 import com.pexip.sdk.api.infinity.readUtf8
 import com.pexip.sdk.infinity.BreakoutId
@@ -67,7 +66,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-internal class EventTest {
+class InfinityEventTest {
 
     @Test
     fun `returns Event if the type is registered`() {
@@ -112,13 +111,13 @@ internal class EventTest {
                 val3 = IncomingEvent(
                     conferenceAlias = "george@example.com",
                     remoteDisplayName = "George",
-                    token = "CXU3tuRZbF673lPdVbg9p3ZtOv7iuTOO0BSo2yFF1U9_qxKdlQAMr2wNZBwW1xccPMgFEI_MjF9SpRzu6nxi5zwaXdOsQbblemYYOn8pShCT1bn1QIWx0RC0H-L4heWaGQXY1dpIByDInVK5vLu88Uv0cb_dbxzhrlaIfm9_WP9YLmCVsvmFOhmDKx0bZxRTOP_yziFjl5xNxWAJQ8NL3assEFIfptXGN89Fp6jomreIOSktfVlSnMJe1OG6fqeiKYQS4WP-ie2d3nQ1tVFfxzYeU0fGHh4Wvxqozmbqs_zjpg==",
+                    token = "CXU",
                 ),
             )
             .row(
                 val1 = "incoming_cancelled",
                 val2 = "incoming_cancelled.json",
-                val3 = IncomingCancelledEvent("CXU3tuRZbF673lPdVbg9p3ZtOv7iuTOO0BSo2yFF1U9_qxKdlQAMr2wNZBwW1xccPMgFEI_MjF9SpRzu6nxi5zwaXdOsQbblemYYOn8pShCT1bn1QIWx0RC0H-L4heWaGQXY1dpIByDInVK5vLu88Uv0cb_dbxzhrlaIfm9_WP9YLmCVsvmFOhmDKx0bZxRTOP_yziFjl5xNxWAJQ8NL3assEFIfptXGN89Fp6jomreIOSktfVlSnMJe1OG6fqeiKYQS4WP-ie2d3nQ1tVFfxzYeU0fGHh4Wvxqozmbqs_zjpg=="),
+                val3 = IncomingCancelledEvent("CXU"),
             )
             .row(
                 val1 = "fecc",
@@ -161,7 +160,7 @@ internal class EventTest {
                 val2 = "refer.json",
                 val3 = ReferEvent(
                     conferenceAlias = "toto",
-                    token = "ZqWyw87Yr03g-vH_VCqZBTMemTcmcwwUrHIpq9LWl8Kn8DGc1yBmeMSN-ux5KRsO70QRtOvLfyoasEeioIve4wsUgCAsi6y_GUqc2Af40TcCHRm3RF5fEUqPo0x8P32Nc3BhmaTk5Mz2YP8t8v5YCggcaHDU1d_ddWZszWUwa_sszv-9h3FxmpTzT-zuB67RXfdBQlStbt86paf5S-6E9kzB2QJCKfrB1U9-juF-czmMibaEODEVC88V2Rlf8GIer2w=",
+                    token = "ZqW",
                 ),
             )
             .row(
@@ -361,8 +360,7 @@ internal class EventTest {
             )
             .forAll { type, filename, event ->
                 val data = FileSystem.RESOURCES.readUtf8(filename)
-                val actual = Event(
-                    json = InfinityService.Json,
+                val actual = InfinityEvent(
                     id = Random.nextString(),
                     type = type,
                     data = data.trim(),
@@ -373,12 +371,11 @@ internal class EventTest {
 
     @Test
     fun `returns null if the type is not registered`() {
-        val actual = Event(
-            json = InfinityService.Json,
+        val actual = InfinityEvent(
             id = Random.nextString(),
             type = Random.nextString(),
             data = Random.nextString(),
         )
-        assertThat(actual, "event").isNull()
+        assertThat(actual, "event").isEqualTo(UnknownEvent)
     }
 }

--- a/sdk-api/src/test/resources/incoming.json
+++ b/sdk-api/src/test/resources/incoming.json
@@ -4,5 +4,5 @@
   "remote_alias": "George",
   "remote_display_name": "George",
   "service_type": "gateway",
-  "token": "CXU3tuRZbF673lPdVbg9p3ZtOv7iuTOO0BSo2yFF1U9_qxKdlQAMr2wNZBwW1xccPMgFEI_MjF9SpRzu6nxi5zwaXdOsQbblemYYOn8pShCT1bn1QIWx0RC0H-L4heWaGQXY1dpIByDInVK5vLu88Uv0cb_dbxzhrlaIfm9_WP9YLmCVsvmFOhmDKx0bZxRTOP_yziFjl5xNxWAJQ8NL3assEFIfptXGN89Fp6jomreIOSktfVlSnMJe1OG6fqeiKYQS4WP-ie2d3nQ1tVFfxzYeU0fGHh4Wvxqozmbqs_zjpg=="
+  "token": "CXU"
 }

--- a/sdk-api/src/test/resources/incoming_cancelled.json
+++ b/sdk-api/src/test/resources/incoming_cancelled.json
@@ -1,3 +1,3 @@
 {
-  "token": "CXU3tuRZbF673lPdVbg9p3ZtOv7iuTOO0BSo2yFF1U9_qxKdlQAMr2wNZBwW1xccPMgFEI_MjF9SpRzu6nxi5zwaXdOsQbblemYYOn8pShCT1bn1QIWx0RC0H-L4heWaGQXY1dpIByDInVK5vLu88Uv0cb_dbxzhrlaIfm9_WP9YLmCVsvmFOhmDKx0bZxRTOP_yziFjl5xNxWAJQ8NL3assEFIfptXGN89Fp6jomreIOSktfVlSnMJe1OG6fqeiKYQS4WP-ie2d3nQ1tVFfxzYeU0fGHh4Wvxqozmbqs_zjpg=="
+  "token": "CXU"
 }

--- a/sdk-api/src/test/resources/refer.json
+++ b/sdk-api/src/test/resources/refer.json
@@ -1,4 +1,4 @@
 {
   "alias": "toto",
-  "token": "ZqWyw87Yr03g-vH_VCqZBTMemTcmcwwUrHIpq9LWl8Kn8DGc1yBmeMSN-ux5KRsO70QRtOvLfyoasEeioIve4wsUgCAsi6y_GUqc2Af40TcCHRm3RF5fEUqPo0x8P32Nc3BhmaTk5Mz2YP8t8v5YCggcaHDU1d_ddWZszWUwa_sszv-9h3FxmpTzT-zuB67RXfdBQlStbt86paf5S-6E9kzB2QJCKfrB1U9-juF-czmMibaEODEVC88V2Rlf8GIer2w="
+  "token": "ZqW"
 }


### PR DESCRIPTION
Previously, we'd use `when (type)` to distinguish between the type of
the incoming event and handle the deserialization manually.

With this change, we switch to generated serializers by creating a
"fake" JSON that wraps `type` and `data`. We use `#event` as the type
discriminator since we know that it will not be included in `data`.
