### PR TITLE
feat(media): add VideoTrackEmbeddedRenderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - A `disconnect` signal to let Infinity know that the `MediaConnection` is going away
 - `ConferenceStep.conference(String)` to create a new `ConferenceStep` using a different alias
+- `VideoTrackEmbeddedRenderer` as an alternative to `VideoTrackRenderer`
 
 ### Changed
 

--- a/sample/src/main/kotlin/com/pexip/sdk/sample/conference/ConferenceScreen.kt
+++ b/sample/src/main/kotlin/com/pexip/sdk/sample/conference/ConferenceScreen.kt
@@ -29,7 +29,6 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.safeContentPadding
@@ -59,6 +58,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -67,7 +67,7 @@ import coil.compose.AsyncImage
 import com.pexip.sdk.conference.Element
 import com.pexip.sdk.conference.SplashScreen
 import com.pexip.sdk.media.AudioDevice
-import com.pexip.sdk.media.webrtc.compose.FrameResolution
+import com.pexip.sdk.media.webrtc.compose.VideoTrackEmbeddedRenderer
 import com.pexip.sdk.media.webrtc.compose.VideoTrackRenderer
 import com.pexip.sdk.sample.CameraIconButton
 import com.pexip.sdk.sample.IconButton
@@ -133,13 +133,6 @@ fun ConferenceScreen(
                         .fillMaxSize()
                         .safeContentPadding(),
                 ) {
-                    val (frameResolution, onFrameResolutionChange) = remember {
-                        mutableStateOf<FrameResolution?>(null)
-                    }
-                    val aspectRatioModifier = when (frameResolution) {
-                        null -> Modifier
-                        else -> Modifier.aspectRatio(frameResolution.rotatedAspectRatio)
-                    }
                     AnimatedVisibility(
                         visible = rendering.cameraVideoTrackRendering?.capturing == true,
                         enter = slideInHorizontally { it * 2 },
@@ -147,15 +140,11 @@ fun ConferenceScreen(
                         modifier = Modifier
                             .align(Alignment.TopEnd)
                             .fillMaxWidth(0.25f)
-                            .then(aspectRatioModifier),
+                            .shadow(elevation = 8.dp, shape = MaterialTheme.shapes.medium),
                     ) {
-                        val scalingType = RendererCommon.ScalingType.SCALE_ASPECT_FIT
-                        VideoTrackRenderer(
+                        VideoTrackEmbeddedRenderer(
                             videoTrack = rendering.cameraVideoTrack,
                             mirror = true,
-                            zOrderMediaOverlay = true,
-                            onFrameResolutionChange = onFrameResolutionChange,
-                            scalingTypeMatchOrientation = scalingType,
                         )
                     }
                     Row(

--- a/sdk-media-webrtc-compose/api/sdk-media-webrtc-compose.api
+++ b/sdk-media-webrtc-compose/api/sdk-media-webrtc-compose.api
@@ -22,6 +22,10 @@ public final class com/pexip/sdk/media/webrtc/compose/FrameResolution {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/pexip/sdk/media/webrtc/compose/VideoTrackEmbeddedRendererKt {
+	public static final fun VideoTrackEmbeddedRenderer (Lcom/pexip/sdk/media/VideoTrack;Landroidx/compose/ui/Modifier;ZLandroidx/compose/runtime/Composer;II)V
+}
+
 public final class com/pexip/sdk/media/webrtc/compose/VideoTrackRendererKt {
 	public static final fun VideoTrackRenderer (Lcom/pexip/sdk/media/VideoTrack;Landroidx/compose/ui/Modifier;ZZZZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lorg/webrtc/RendererCommon$ScalingType;Lorg/webrtc/RendererCommon$ScalingType;Landroidx/compose/runtime/Composer;II)V
 }

--- a/sdk-media-webrtc-compose/src/main/kotlin/com/pexip/sdk/media/webrtc/compose/VideoTrackEmbeddedRenderer.kt
+++ b/sdk-media-webrtc-compose/src/main/kotlin/com/pexip/sdk/media/webrtc/compose/VideoTrackEmbeddedRenderer.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2024 Pexip AS
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.pexip.sdk.media.webrtc.compose
+
+import androidx.compose.foundation.AndroidEmbeddedExternalSurface
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.pexip.sdk.media.Renderer
+import com.pexip.sdk.media.VideoTrack
+import org.webrtc.GlRectDrawer
+import org.webrtc.RendererCommon
+import org.webrtc.ThreadUtils
+import java.util.concurrent.CountDownLatch
+
+/**
+ * Renders a [VideoTrack] embedded directly in the UI hierarchy.
+ *
+ * Unlike [VideoTrackRenderer] it positions its surface as a regular element inside
+ * the composable hierarchy and seamlessly supports clipping.
+ *
+ * @param videoTrack an instance of video track or null
+ * @param modifier optional [Modifier] to be applied to the video
+ * @param mirror defines if the video should rendered mirrored
+ */
+@Composable
+public fun VideoTrackEmbeddedRenderer(
+    videoTrack: VideoTrack?,
+    modifier: Modifier = Modifier,
+    mirror: Boolean = false,
+) {
+    val eglBase = LocalEglBase.current
+    val eglBaseContext = remember(eglBase) { eglBase?.eglBaseContext }
+    val eglBaseConfigAttributes = LocalEglBaseConfigAttributes.current
+    val renderer = remember { SurfaceEglRenderer("VideoTrackEmbeddedRenderer") }
+    var aspectRatio by remember { mutableFloatStateOf(0f) }
+    DisposableEffect(renderer, eglBaseContext) {
+        val events = object : RendererCommon.RendererEvents {
+
+            override fun onFirstFrameRendered() = Unit
+
+            override fun onFrameResolutionChanged(width: Int, height: Int, rotation: Int) {
+                aspectRatio = when (rotation % 180) {
+                    0 -> width / height.toFloat()
+                    else -> height / width.toFloat()
+                }
+            }
+        }
+        renderer.init(eglBaseContext, events, eglBaseConfigAttributes, GlRectDrawer())
+        onDispose {
+            renderer.clearImage()
+            renderer.release()
+        }
+    }
+    DisposableEffect(renderer, videoTrack) {
+        videoTrack?.addRenderer(renderer)
+        onDispose {
+            videoTrack?.removeRenderer(renderer)
+            renderer.clearImage()
+        }
+    }
+    LaunchedEffect(renderer, mirror) {
+        renderer.setMirror(mirror)
+    }
+    LaunchedEffect(renderer, aspectRatio) {
+        renderer.setLayoutAspectRatio(aspectRatio)
+    }
+    if (aspectRatio != 0f) {
+        AndroidEmbeddedExternalSurface(modifier = modifier.aspectRatio(aspectRatio)) {
+            onSurface { surface, _, _ ->
+                renderer.createEglSurface(surface)
+                surface.onDestroyed {
+                    val latch = CountDownLatch(1)
+                    renderer.releaseEglSurface(latch::countDown)
+                    ThreadUtils.awaitUninterruptibly(latch)
+                }
+            }
+        }
+    }
+}
+
+private class SurfaceEglRenderer(name: String) :
+    org.webrtc.SurfaceEglRenderer(name),
+    Renderer


### PR DESCRIPTION
This is a TextureView-based Composable that is embedded directly in the
UI hierarchy.

Unlike `VideoTrackRenderer` effects such as clipping can be safely
applied to this Composable (see the modified self-view for an example of
this).
