### PR TITLE
feat(api): set breakout_capable to false by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Microphone mute to rely on `AudioDeviceModule.setMicrophoneMute(Boolean)` instead of
   `AudioManager.setMicrophoneMute(Boolean)`
 - Noise suppressor and acoustic echo canceler to use software implementation
-- Explicitly set `breakout_capable` to `false` to make breakouts opt-in 
+- Explicitly set `breakout_capable` to `false` to make breakouts opt-in
 
 ## [0.16.0] - 2024-10-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Microphone mute to rely on `AudioDeviceModule.setMicrophoneMute(Boolean)` instead of
   `AudioManager.setMicrophoneMute(Boolean)`
 - Noise suppressor and acoustic echo canceler to use software implementation
+- Explicitly set `breakout_capable` to `false` to make breakouts opt-in 
 
 ## [0.16.0] - 2024-10-02
 

--- a/sdk-api/api/sdk-api.api
+++ b/sdk-api/api/sdk-api.api
@@ -1395,8 +1395,8 @@ public final class com/pexip/sdk/api/infinity/RequestRegistrationTokenResponse$C
 
 public final class com/pexip/sdk/api/infinity/RequestTokenRequest {
 	public static final field Companion Lcom/pexip/sdk/api/infinity/RequestTokenRequest$Companion;
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3-BqYgc20 ()Ljava/lang/String;
@@ -1405,9 +1405,11 @@ public final class com/pexip/sdk/api/infinity/RequestTokenRequest {
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Z
 	public final fun component8 ()Ljava/lang/String;
-	public final fun copy-0YY_9dw (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;)Lcom/pexip/sdk/api/infinity/RequestTokenRequest;
-	public static synthetic fun copy-0YY_9dw$default (Lcom/pexip/sdk/api/infinity/RequestTokenRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/RequestTokenRequest;
+	public final fun component9 ()Z
+	public final fun copy-NVC4iYU (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;Z)Lcom/pexip/sdk/api/infinity/RequestTokenRequest;
+	public static synthetic fun copy-NVC4iYU$default (Lcom/pexip/sdk/api/infinity/RequestTokenRequest;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLjava/lang/String;ZILjava/lang/Object;)Lcom/pexip/sdk/api/infinity/RequestTokenRequest;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBreakoutCapable ()Z
 	public final fun getCallTag ()Ljava/lang/String;
 	public final fun getChosenIdp-BqYgc20 ()Ljava/lang/String;
 	public final fun getConferenceExtension ()Ljava/lang/String;

--- a/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/RequestTokenRequest.kt
+++ b/sdk-api/src/main/kotlin/com/pexip/sdk/api/infinity/RequestTokenRequest.kt
@@ -15,9 +15,12 @@
  */
 package com.pexip.sdk.api.infinity
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 public data class RequestTokenRequest(
     @SerialName("conference_extension")
@@ -36,4 +39,7 @@ public data class RequestTokenRequest(
     val directMedia: Boolean = false,
     @SerialName("call_tag")
     val callTag: String = "",
+    @EncodeDefault
+    @SerialName("breakout_capable")
+    val breakoutCapable: Boolean = false,
 )


### PR DESCRIPTION
This means that consumers should explicitly opt-in to support breakouts
feature. By default, this is not supported and the behavior matches that
of a guest on Infinity v36+.

Note that on v34 and v35 if the participant is being transfered to a
breakout they may not receive `refer` event, which means that they will
stay in the main room.
