### PR TITLE
ci: migrate from s01 to central

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,10 +31,10 @@ jobs:
       - run: ./gradlew build
       - run: ./gradlew publish --no-parallel
         env:
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SONATYPE_GPG_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SONATYPE_GPG_PASSPHRASE }}
-          ORG_GRADLE_PROJECT_MavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
-          ORG_GRADLE_PROJECT_MavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SONATYPE_GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SONATYPE_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
 
       - run: ./gradlew dokkaHtmlMultiModule
         if: ${{ startsWith(github.event.head_commit.message, 'release:') }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,6 +1,6 @@
 name: 'pull request'
 
-on: [pull_request, merge_group]
+on: [ pull_request, merge_group ]
 
 env:
   CI: 'true'
@@ -27,8 +27,8 @@ jobs:
       - run: ./gradlew build
       - run: ./gradlew publishToMavenLocal --no-parallel
         env:
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SONATYPE_GPG_KEY }}
-          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SONATYPE_GPG_PASSPHRASE }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SONATYPE_GPG_KEY }}
+          ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SONATYPE_GPG_PASSPHRASE }}
 
   snyk_test:
     runs-on: ubuntu-latest

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,8 +5,6 @@
 3. Replace current version name in `README.md` and `bug_report.yml`
 4. Add relevant changes to `CHANGELOG.md` and an entry for the next version
 5. Create and merge a pull request with the commit message `release: 1.2.3`
-6. Follow [Maven Central guide](https://central.sonatype.org/publish/release/) on release
-   process in Sonatype
-7. Update `gradle.properties` `version` with the next snapshot version (e.g. `1.2.4-SNAPSHOT`)
-8. Create and merge a pull request with the commit message
+6. Update `gradle.properties` `version` with the next snapshot version (e.g. `1.2.4-SNAPSHOT`)
+7. Create and merge a pull request with the commit message
    `snapshot: prepare next development iteration`

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.dagger.hilt.android) apply false
     alias(libs.plugins.kotlin.jvm) apply false
     alias(libs.plugins.ksp) apply false
+    id("com.pexip.sdk.publishing") apply false
 }
 
 group = checkNotNull(property("group")) { "group == null." }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,7 @@ okhttp-tls = { module = "com.squareup.okhttp3:okhttp-tls", version.ref = "okhttp
 okhttp-logginginterceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
+publish = { module = "com.vanniktech.maven.publish:com.vanniktech.maven.publish.gradle.plugin", version = "0.31.0" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
 webrtc = { module = "com.pexip.webrtc:webrtc", version.ref = "webrtc" }
 workflow-core-jvm = { module = "com.squareup.workflow1:workflow-core-jvm", version.ref = "workflow" }

--- a/plugins/convention/build.gradle.kts
+++ b/plugins/convention/build.gradle.kts
@@ -57,4 +57,5 @@ dependencies {
     implementation(libs.dokka.base)
     implementation(libs.kotlin)
     implementation(libs.licensee)
+    implementation(libs.publish)
 }

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinAndroidLibraryPublishingPlugin.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinAndroidLibraryPublishingPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Pexip AS
+ * Copyright 2023-2025 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
  */
 package com.pexip.sdk
 
-import com.android.build.api.dsl.LibraryExtension
+import com.vanniktech.maven.publish.AndroidSingleVariantLibrary
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.publish.PublishingExtension
@@ -23,7 +24,7 @@ import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.get
+import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.withType
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
@@ -38,24 +39,17 @@ class KotlinAndroidLibraryPublishingPlugin : Plugin<Project> {
             apply(LicenseePlugin::class)
             apply(PublishingPlugin::class)
         }
-        configure<LibraryExtension> {
-            publishing {
-                singleVariant("release") {
-                    withSourcesJar()
-                }
-            }
+        configure<MavenPublishBaseExtension> {
+            configure(AndroidSingleVariantLibrary(publishJavadocJar = false))
         }
         val javadocJar = tasks.register<Jar>("dokkaJavadocJar") {
             from(tasks.named("dokkaJavadoc"))
             archiveClassifier.set("javadoc")
         }
-        configure<PublishingExtension> {
-            publications {
-                register<MavenPublication>("release") {
-                    afterEvaluate {
-                        from(components["release"])
-                        artifact(javadocJar)
-                    }
+        afterEvaluate {
+            configure<PublishingExtension> {
+                publications.named<MavenPublication>("maven") {
+                    artifact(javadocJar)
                 }
             }
         }

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinJvmPublishingPlugin.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinJvmPublishingPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Pexip AS
+ * Copyright 2023-2025 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,17 +15,13 @@
  */
 package com.pexip.sdk
 
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinJvm
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.plugins.JavaPluginExtension
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.named
-import org.gradle.kotlin.dsl.register
 
 class KotlinJvmPublishingPlugin : Plugin<Project> {
 
@@ -36,19 +32,8 @@ class KotlinJvmPublishingPlugin : Plugin<Project> {
             apply(LicenseePlugin::class)
             apply(PublishingPlugin::class)
         }
-        configure<JavaPluginExtension> {
-            withJavadocJar()
-            withSourcesJar()
-        }
-        tasks.named<Jar>("javadocJar") {
-            from(tasks.named("dokkaJavadoc"))
-        }
-        configure<PublishingExtension> {
-            publications {
-                register<MavenPublication>("release") {
-                    from(components["java"])
-                }
-            }
+        configure<MavenPublishBaseExtension> {
+            configure(KotlinJvm(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
         }
     }
 }

--- a/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinMultiplatformPublishingPlugin.kt
+++ b/plugins/convention/src/main/kotlin/com/pexip/sdk/KotlinMultiplatformPublishingPlugin.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023-2024 Pexip AS
+ * Copyright 2023-2025 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,15 +15,13 @@
  */
 package com.pexip.sdk
 
+import com.vanniktech.maven.publish.JavadocJar
+import com.vanniktech.maven.publish.KotlinMultiplatform
+import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.publish.PublishingExtension
-import org.gradle.api.publish.maven.MavenPublication
-import org.gradle.jvm.tasks.Jar
 import org.gradle.kotlin.dsl.apply
 import org.gradle.kotlin.dsl.configure
-import org.gradle.kotlin.dsl.register
-import org.gradle.kotlin.dsl.withType
 
 class KotlinMultiplatformPublishingPlugin : Plugin<Project> {
 
@@ -34,16 +32,8 @@ class KotlinMultiplatformPublishingPlugin : Plugin<Project> {
             apply(LicenseePlugin::class)
             apply(PublishingPlugin::class)
         }
-        configure<PublishingExtension> {
-            publications.withType<MavenPublication> {
-                val name = name
-                val javadocJar = tasks.register<Jar>("${name}JavadocJar") {
-                    from(tasks.named("dokkaJavadoc"))
-                    archiveClassifier.set("javadoc")
-                    archiveBaseName.set("${archiveBaseName.get()}-$name")
-                }
-                artifact(javadocJar)
-            }
+        configure<MavenPublishBaseExtension> {
+            configure(KotlinMultiplatform(javadocJar = JavadocJar.Dokka("dokkaJavadoc")))
         }
     }
 }

--- a/sdk-api/build.gradle.kts
+++ b/sdk-api/build.gradle.kts
@@ -23,6 +23,6 @@ dependencies {
     testImplementation(libs.turbine)
 }
 
-publishing.publications.withType<MavenPublication> {
-    pom.description = "A set of common classes and interfaces to build APIs."
+mavenPublishing.pom {
+    description = "A set of common classes and interfaces to build APIs."
 }

--- a/sdk-catalog/build.gradle.kts
+++ b/sdk-catalog/build.gradle.kts
@@ -1,6 +1,8 @@
+import com.vanniktech.maven.publish.VersionCatalog
+
 plugins {
-    id("com.pexip.sdk.publishing")
     `version-catalog`
+    id("com.pexip.sdk.publishing")
 }
 
 catalog {
@@ -28,13 +30,14 @@ val sourcesJar by tasks.register<Jar>("sourcesJar") {
     from(file("README.md"))
 }
 
-publishing {
-    publications {
-        register<MavenPublication>("release") {
-            from(components["versionCatalog"])
-            artifact(javadocJar)
-            artifact(sourcesJar)
-            pom.description = "Gradle Version Catalog for Pexip Android SDK"
-        }
+mavenPublishing {
+    configure(VersionCatalog())
+    pom {
+        description = "Gradle Version Catalog for Pexip Android SDK"
     }
+}
+
+publishing.publications.named<MavenPublication>("maven") {
+    artifact(javadocJar)
+    artifact(sourcesJar)
 }

--- a/sdk-conference/build.gradle.kts
+++ b/sdk-conference/build.gradle.kts
@@ -15,6 +15,6 @@ dependencies {
     testImplementation(libs.turbine)
 }
 
-publishing.publications.withType<MavenPublication> {
-    pom.description = "A set of tools to interact with conferences."
+mavenPublishing.pom {
+    description = "A set of tools to interact with conferences."
 }

--- a/sdk-core/build.gradle.kts
+++ b/sdk-core/build.gradle.kts
@@ -21,6 +21,6 @@ kotlin {
     }
 }
 
-publishing.publications.withType<MavenPublication> {
-    pom.description = "Pexip SDK core"
+mavenPublishing.pom {
+    description = "Pexip SDK core"
 }

--- a/sdk-infinity-test/build.gradle.kts
+++ b/sdk-infinity-test/build.gradle.kts
@@ -13,6 +13,6 @@ kotlin {
     }
 }
 
-publishing.publications.withType<MavenPublication> {
-    pom.description = "Pexip Infinity SDK test utilities"
+mavenPublishing.pom {
+    description = "Pexip Infinity SDK test utilities"
 }

--- a/sdk-infinity/build.gradle.kts
+++ b/sdk-infinity/build.gradle.kts
@@ -19,6 +19,6 @@ kotlin {
     }
 }
 
-publishing.publications.withType<MavenPublication> {
-    pom.description = "Pexip Infinity SDK"
+mavenPublishing.pom {
+    description = "Pexip Infinity SDK"
 }

--- a/sdk-media-android/build.gradle.kts
+++ b/sdk-media-android/build.gradle.kts
@@ -12,6 +12,6 @@ dependencies {
     api(libs.androidx.media)
 }
 
-publishing.publications.withType<MavenPublication>().configureEach {
-    pom.description = "Android-specific extensions for sdk-media."
+mavenPublishing.pom {
+    description = "Android-specific extensions for sdk-media."
 }

--- a/sdk-media-webrtc-compose/build.gradle.kts
+++ b/sdk-media-webrtc-compose/build.gradle.kts
@@ -13,6 +13,6 @@ dependencies {
     implementation(libs.androidx.compose.ui.tooling)
 }
 
-publishing.publications.withType<MavenPublication>().configureEach {
-    pom.description = "Compose support for sdk-media-webrtc."
+mavenPublishing.pom {
+    description = "Compose support for sdk-media-webrtc."
 }

--- a/sdk-media-webrtc/build.gradle.kts
+++ b/sdk-media-webrtc/build.gradle.kts
@@ -16,6 +16,6 @@ dependencies {
     implementation(libs.okio)
 }
 
-publishing.publications.withType<MavenPublication>().configureEach {
-    pom.description = "WebRTC-based implementation of sdk-media."
+mavenPublishing.pom {
+    description = "WebRTC-based implementation of sdk-media."
 }

--- a/sdk-media/build.gradle.kts
+++ b/sdk-media/build.gradle.kts
@@ -6,7 +6,6 @@ dependencies {
     api(libs.kotlinx.coroutines.core)
 }
 
-publishing.publications.withType<MavenPublication>().configureEach {
-    pom.description =
-        "A set of classes and interfaces to help with establishing a media connection."
+mavenPublishing.pom {
+    description = "A set of classes and interfaces to help with establishing a media connection."
 }

--- a/sdk-registration/build.gradle.kts
+++ b/sdk-registration/build.gradle.kts
@@ -13,6 +13,6 @@ dependencies {
     testImplementation(libs.turbine)
 }
 
-publishing.publications.withType<MavenPublication> {
-    pom.description = "A set of tools to interact with registrations."
+mavenPublishing.pom {
+    description = "A set of tools to interact with registrations."
 }


### PR DESCRIPTION
This updates the publishing bit to use new Central host instead of the
old s01, which requires a new authentication method and a new plugin.

Note that we also enable auto release here to avoid going to the
dashboard.
