### PR TITLE
feat(media): add a way to disable built-in mute sync for audio and video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- `MediaConnectionConfig.syncAudioMute` and `MediaConnectionConfig.syncVideoMute` to disable the
+  default mute sync behavior
+
 ## [0.17.1] - 2025-03-10
 
 ### Changed

--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/WebRtcMediaConnection.kt
@@ -132,11 +132,15 @@ internal class WebRtcMediaConnection(
             launchPreferredAspectRatio()
             launchDegradationPreference(Key.MAIN_VIDEO, mainDegradationPreference)
             launchDegradationPreference(Key.PRESENTATION_VIDEO, presentationDegradationPreference)
-            launchLocalMediaTrackCapturing(mainLocalAudioTrack) {
-                if (it) onAudioUnmuted() else onAudioMuted()
+            if (config.syncAudioMute) {
+                launchLocalMediaTrackCapturing(mainLocalAudioTrack) {
+                    if (it) onAudioUnmuted() else onAudioMuted()
+                }
             }
-            launchLocalMediaTrackCapturing(mainLocalVideoTrack) {
-                if (it) onVideoUnmuted() else onVideoMuted()
+            if (config.syncVideoMute) {
+                launchLocalMediaTrackCapturing(mainLocalVideoTrack) {
+                    if (it) onVideoUnmuted() else onVideoMuted()
+                }
             }
             launchLocalMediaTrackCapturing(presentationLocalVideoTrack) {
                 if (it) onTakeFloor() else onReleaseFloor()

--- a/sdk-media/api/sdk-media.api
+++ b/sdk-media/api/sdk-media.api
@@ -206,12 +206,14 @@ public abstract interface class com/pexip/sdk/media/MediaConnection$RemoteVideoT
 }
 
 public final class com/pexip/sdk/media/MediaConnectionConfig {
-	public synthetic fun <init> (Lcom/pexip/sdk/media/MediaConnectionSignaling;Ljava/util/List;ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/pexip/sdk/media/MediaConnectionSignaling;Ljava/util/List;ZZZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getDscp ()Z
 	public final fun getFarEndCameraControl ()Z
 	public final fun getIceServers ()Ljava/util/List;
 	public final fun getPresentationInMain ()Z
 	public final fun getSignaling ()Lcom/pexip/sdk/media/MediaConnectionSignaling;
+	public final fun getSyncAudioMute ()Z
+	public final fun getSyncVideoMute ()Z
 }
 
 public final class com/pexip/sdk/media/MediaConnectionConfig$Builder {
@@ -221,6 +223,8 @@ public final class com/pexip/sdk/media/MediaConnectionConfig$Builder {
 	public final fun dscp (Z)Lcom/pexip/sdk/media/MediaConnectionConfig$Builder;
 	public final fun farEndCameraControl (Z)Lcom/pexip/sdk/media/MediaConnectionConfig$Builder;
 	public final fun presentationInMain (Z)Lcom/pexip/sdk/media/MediaConnectionConfig$Builder;
+	public final fun syncAudioMute (Z)Lcom/pexip/sdk/media/MediaConnectionConfig$Builder;
+	public final fun syncVideoMute (Z)Lcom/pexip/sdk/media/MediaConnectionConfig$Builder;
 }
 
 public abstract interface class com/pexip/sdk/media/MediaConnectionFactory : com/pexip/sdk/media/CameraVideoTrackFactory, com/pexip/sdk/media/LocalAudioTrackFactory {

--- a/sdk-media/src/main/kotlin/com/pexip/sdk/media/MediaConnectionConfig.kt
+++ b/sdk-media/src/main/kotlin/com/pexip/sdk/media/MediaConnectionConfig.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Pexip AS
+ * Copyright 2022-2025 Pexip AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ package com.pexip.sdk.media
  * @property dscp true if DSCP is enabled, false otherwise
  * @property presentationInMain true if presentation will be mixed with main video feed, false otherwise; ignored for direct media calls
  * @property farEndCameraControl true if far end camera control is supported, false otherwise
+ * @property syncAudioMute true if audio mute should be synced, false otherwise
+ * @property syncVideoMute true if video mute should be synced, false otherwise
  */
 public class MediaConnectionConfig private constructor(
     public val signaling: MediaConnectionSignaling,
@@ -30,6 +32,8 @@ public class MediaConnectionConfig private constructor(
     public val dscp: Boolean,
     public val presentationInMain: Boolean,
     public val farEndCameraControl: Boolean,
+    public val syncAudioMute: Boolean,
+    public val syncVideoMute: Boolean,
 ) {
 
     /**
@@ -43,6 +47,8 @@ public class MediaConnectionConfig private constructor(
         private var dscp = false
         private var presentationInMain = false
         private var farEndCameraControl = false
+        private var syncAudioMute = true
+        private var syncVideoMute = true
 
         /**
          * Adds an [IceServer] to this builder.
@@ -92,6 +98,26 @@ public class MediaConnectionConfig private constructor(
         }
 
         /**
+         * Sets whether audio mute state should be synced.
+         *
+         * @param syncAudioMute true if audio mute should be synced, false otherwise
+         * @return this builder
+         */
+        public fun syncAudioMute(syncAudioMute: Boolean): Builder = apply {
+            this.syncAudioMute = syncAudioMute
+        }
+
+        /**
+         * Sets whether video mute state should be synced.
+         *
+         * @param syncVideoMute true if video mute should be synced, false otherwise
+         * @return this builder
+         */
+        public fun syncVideoMute(syncVideoMute: Boolean): Builder = apply {
+            this.syncVideoMute = syncVideoMute
+        }
+
+        /**
          * Builds [MediaConnectionConfig].
          *
          * @return an instance of [MediaConnectionConfig]
@@ -102,6 +128,8 @@ public class MediaConnectionConfig private constructor(
             dscp = dscp,
             presentationInMain = presentationInMain && !signaling.directMedia,
             farEndCameraControl = farEndCameraControl,
+            syncAudioMute = syncAudioMute,
+            syncVideoMute = syncVideoMute,
         )
     }
 }


### PR DESCRIPTION
The one included in the SDK is pretty basic and may not cover
all the cases, so this gives clients a way to disable it and use their
own logic instead.
