### PR TITLE
fix(media): avoid skipping potential ICE candidates

### DIFF
--- a/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/PeerConnectionWrapper.kt
+++ b/sdk-media-webrtc/src/main/kotlin/com/pexip/sdk/media/webrtc/internal/PeerConnectionWrapper.kt
@@ -58,7 +58,7 @@ internal class PeerConnectionWrapper(
 ) {
 
     private val mutex = Mutex()
-    private val observer = Observer(rtcConfig.continualGatheringPolicy)
+    private val observer = Observer()
     private var peerConnection by Delegates.observable<PeerConnection?>(null) { _, old, _ ->
         old?.dispose()
     }


### PR DESCRIPTION
ICE candidates that had the same `sdpMid` value were previously skipped when `ContinualGatheringPolicy` was set to `ContinualGatheringPolicy.GATHER_ONCE`(default), leading to potential connectivity issues as the candidates may have different content in the `sdp` itself. This potential fix removes this equality check and ensures that all candidates are signalled to the remote client.